### PR TITLE
[FIX] : Live version issues

### DIFF
--- a/src/assetbundles/dist/js/health-check.js
+++ b/src/assetbundles/dist/js/health-check.js
@@ -394,7 +394,7 @@ function toggleShowDetails(domainDetailsSection) {
 
 function registerLighthouseJs() {
     const deviceSelector = document.getElementById("device-selector");
-    const refreshBtn = document.getElementById("refresh-btn");
+    const refreshBtn = document.getElementById("refresh-button");
     let currentDevice = deviceSelector?.value || 'desktop';
 
     const scoresContainer = document.getElementById("scores-container");
@@ -467,7 +467,7 @@ function registerLighthouseJs() {
             // Add loading state to button
             refreshBtn.disabled = true;
             refreshBtn.innerHTML = '<span class="spinner"></span> Refreshing...';
-
+            showLoaderSkeleton();
             fetchLighthouseData(currentDevice).finally(() => {
                 // Reset button state
                 refreshBtn.disabled = false;

--- a/src/assetbundles/dist/js/health-check.js
+++ b/src/assetbundles/dist/js/health-check.js
@@ -483,6 +483,16 @@ function registerLighthouseJs() {
         if (statusWrapper && detailsWrapper) {
             statusWrapper.innerHTML = `
             <div class="skeleton-card">
+				<div class="skeleton-card-body">
+					<div>
+						<h3>
+							Fetching your scores. Please hang tight as it takes around 30 seconds
+							<span class="loading-dots"></span>
+						</h3>
+					</div>
+				</div>
+			</div>
+            <div class="skeleton-card">
                 <div class="skeleton-card-header">
                     <div class="skeleton-line skeleton-line-medium"></div>
                 </div>

--- a/src/assetbundles/dist/js/settings.js
+++ b/src/assetbundles/dist/js/settings.js
@@ -43,7 +43,7 @@ Craft.Upsnap.Settings = {
 
         if (!Craft.Upsnap.Settings.isValidUrl(urlValue)) {
             event.preventDefault();
-            alert('Please enter a valid URL starting with https://');
+            Craft.cp.displayError('Please enter a valid URL starting with https://');
             return false;
         }
 

--- a/src/icon-mask.svg
+++ b/src/icon-mask.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="45" fill="#007bff"/>
+  <text x="50" y="60" text-anchor="middle" fill="white" font-size="20">UpSnap</text>
+</svg>

--- a/src/templates/healthcheck/lighthouse.twig
+++ b/src/templates/healthcheck/lighthouse.twig
@@ -11,7 +11,7 @@
 				<option value="mobile">{{ 'Mobile'|t('upsnap') }}</option>
 			</select>
 		</div>
-		<button type="button" class="btn submit" data-icon="refresh" id="refresh-btn">
+		<button type="button" class="btn submit" data-icon="refresh" id="refresh-button">
 			{{ 'Refresh'|t('upsnap') }}
 		</button>
 	</div>

--- a/src/templates/settings/_index.twig
+++ b/src/templates/settings/_index.twig
@@ -3,7 +3,9 @@
 
 {% block actionButton %}
     <div class="buttons">
-        <button type="submit" class="btn submit">{{ "Save"|t('upsnap') }}</button>
+        <button type="submit" form="settings-form" class="btn submit">
+            {{ "Save"|t('upsnap') }}
+        </button>
     </div>
 {% endblock %}
 

--- a/src/templates/settings/_index.twig
+++ b/src/templates/settings/_index.twig
@@ -1,6 +1,12 @@
 {% extends "_layouts/cp" %}
 {% import "_includes/forms" as forms %}
 
+{% block actionButton %}
+    <div class="buttons">
+        <button type="submit" class="btn submit">{{ "Save"|t('upsnap') }}</button>
+    </div>
+{% endblock %}
+
 {% block content %}
     <form id="settings-form" method="post" enctype="multipart/form-data">
         <!-- CSRF token and other hidden inputs -->
@@ -53,8 +59,5 @@
             </div>
         </div>
 
-        <div class="buttons">
-            <button type="submit" class="btn submit">{{ "Save"|t('upsnap') }}</button>
-        </div>
     </form>
 {% endblock %}


### PR DESCRIPTION
Contains fixes for the https://github.com/Appfoster/site-monitor/issues/9

- Show the loading message ("Fetching your scores. Please hang tight as it takes around 30 seconds") not just during Lighthouse page load but also when the device type is changed.  
- Make sure the device selection remains consistent; currently, switching to mobile and refreshing resets it to desktop. After refreshing, the scores should correspond to the selected device.  
- Replace the alert for HTTP URLs when adding a URL with a craft notification, avoiding a page reload.  
- Update the save button position on the settings page

<img width="1919" height="993" alt="image" src="https://github.com/user-attachments/assets/1232d944-7593-4372-ad81-6273a159ef1c" />
<img width="537" height="996" alt="image" src="https://github.com/user-attachments/assets/31c48e84-b251-48c2-9d7e-271db91e00d4" />
