### PR TITLE
feat: password protect field added on the status page

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -19,6 +19,7 @@ class Constants
     // API Configuration
     public const API_BASE_URL_DEFAULT = 'https://api.upsnap.ai';
     public const UPSNAP_DASHBOARD_URL = 'https://upsnap.ai';
+    public const UPSNAP_STATS_PAGE_URL = 'https://stats.upsnap.ai';
     public const API_VERSION = 'v1';
     // API Endpoints
     public const ENDPOINT_HEALTHCHECK = 'healthcheck';

--- a/src/assetbundles/dist/css/status-page.css
+++ b/src/assetbundles/dist/css/status-page.css
@@ -139,3 +139,23 @@
 .menu-btn {
 	padding-bottom: 2px !important;
 }
+
+/* Password protection */
+.status-page-lock-icon {
+	margin-left: 5px;
+	color: #8f98a3;
+	opacity: 0.8;
+}
+
+.status-page-lock-icon:hover {
+	opacity: 1;
+	color: #606060;
+}
+
+.field.hidden {
+	display: none !important;
+}
+
+.field {
+	transition: opacity 0.2s ease-in-out;
+}

--- a/src/assetbundles/dist/js/status-pages.js
+++ b/src/assetbundles/dist/js/status-pages.js
@@ -335,7 +335,6 @@ Craft.Upsnap.StatusPages = {
 					payload.is_protected = true;
 					payload.password = password;
 				}
-				// If not protected in create mode, don't send these fields
 			}
 
 			this.disableSavebtn();

--- a/src/assetbundles/dist/js/status-pages.js
+++ b/src/assetbundles/dist/js/status-pages.js
@@ -83,7 +83,7 @@ Craft.Upsnap.StatusPages = {
 		const viewIcon = page.is_published
 			? `
             <a
-                href="${window.Upsnap.upsnapDashboardUrl}/shared/${page.shareable_id}"
+                href="${window.Upsnap.upsnapStatsPageUrl}/shared/${page.shareable_id}"
                 class="btn icon"
                 target="_blank"
                 title="View Status Page"

--- a/src/assetbundles/dist/js/status-pages.js
+++ b/src/assetbundles/dist/js/status-pages.js
@@ -27,12 +27,15 @@ Craft.Upsnap.StatusPages = {
 	initForm() {
 		this.form = document.getElementById("status-page-form");
 		this.nameInput = document.getElementById("name");
+		this.isProtectedInput = document.getElementById("is_protected");
+		this.passwordInput = document.getElementById("password");
 		this.multiSelectContainer = document.getElementById(
 			"monitor-multiselect"
 		);
 
 		this.fetchMonitors();
 		this.registerFormSubmit();
+		this.registerPasswordProtection();
 	},
 
 	cacheElements() {
@@ -96,9 +99,13 @@ Craft.Upsnap.StatusPages = {
             </span>
         `;
 
+		const lockIcon = page.is_protected 
+			? '<span data-icon="lock" class="status-page-lock-icon" title="Password Protected"></span>' 
+			: '';
+
 		tr.innerHTML = `
         <td>
-            <strong>${Craft.escapeHtml(page.name)}</strong>
+            <strong>${Craft.escapeHtml(page.name)}</strong>${lockIcon}
 			 <div class="light smalltext">
             ${monitorsCount} monitor${monitorsCount === 1 ? "" : "s"}
         </div>
@@ -270,14 +277,17 @@ Craft.Upsnap.StatusPages = {
 			e.preventDefault();
 
 			const name = this.nameInput.value.trim();
+			
+			// Get the lightswitch button and its hidden input
+			const lightswitchBtn = document.getElementById("is_protected");
+			const hiddenInput = lightswitchBtn?.querySelector('input[type="hidden"]');
+			// Check the hidden input value OR the aria-checked attribute
+			const isProtected = hiddenInput?.value === "1" || lightswitchBtn?.getAttribute("aria-checked") === "true";
+			
+			const password = this.passwordInput.value;
 
-			if (!name) {
-				Craft.cp.displayError("Name is required.");
-				return;
-			}
-
-			if (!this.selectedMonitors.size) {
-				Craft.cp.displayError("Select at least one monitor.");
+			// Validate form
+			if (!this.validateForm(name, isProtected, password)) {
 				return;
 			}
 
@@ -286,7 +296,13 @@ Craft.Upsnap.StatusPages = {
 				name,
 				monitor_ids: Array.from(this.selectedMonitors.keys()),
 				is_published: true,
+				is_protected: isProtected,
 			};
+
+			// Only include password in payload if protection is enabled and password is provided
+			if (isProtected && password) {
+				payload.password = password;
+			}
 
 			this.disableSavebtn();
 			this.saveStatusPage(payload);
@@ -313,6 +329,104 @@ Craft.Upsnap.StatusPages = {
 			}
 		);
 	},
+	validateForm(name, isProtected, password) {
+		if (!name) {
+			Craft.cp.displayError("Name is required.");
+			return false;
+		}
+
+		if (!this.selectedMonitors.size) {
+			Craft.cp.displayError("Select at least one monitor.");
+			return false;
+		}
+
+		// For new pages or when changing protection status, validate password
+		if (isProtected) {
+			const isEditingExistingProtectedPage = 
+				window.Upsnap?.statusPage?.id && 
+				window.Upsnap?.statusPage?.is_protected;
+
+			// Require password for new protected pages or when editing and changing password
+			if (!isEditingExistingProtectedPage && !password) {
+				Craft.cp.displayError("Password is required when page protection is enabled.");
+				return false;
+			}
+
+			// Validate password complexity if password is provided
+			if (password && !this.validatePassword(password)) {
+				return false;
+			}
+		}
+
+		return true;
+	},
+
+	validatePassword(password) {
+		if (password.length < 8) {
+			Craft.cp.displayError("Password must be at least 8 characters long.");
+			return false;
+		}
+
+		const hasUppercase = /[A-Z]/.test(password);
+		const hasLowercase = /[a-z]/.test(password);
+		const hasNumber = /\d/.test(password);
+		const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+
+		if (!hasUppercase || !hasLowercase || !hasNumber || !hasSpecialChar) {
+			Craft.cp.displayError(
+				"Password must contain uppercase, lowercase, number, and special character."
+			);
+			return false;
+		}
+
+		return true;
+	},
+
+	registerPasswordProtection() {
+		// The lightswitch is a <button> element, not an input
+		const lightswitchBtn = document.getElementById("is_protected");
+		if (!lightswitchBtn || !this.passwordInput) return;
+
+		// Get the hidden input inside the lightswitch button
+		const hiddenInput = lightswitchBtn.querySelector('input[type="hidden"]');
+		
+		// Get the password field container - Craft wraps inputs in a .field div
+		const passwordField = this.passwordInput.closest(".field");
+		if (!passwordField) {
+			console.error("Password field container not found");
+			return;
+		}
+
+		// Function to update password field visibility
+		const updatePasswordFieldVisibility = () => {
+			// Check the hidden input value OR the aria-checked attribute
+			const isProtected = hiddenInput?.value === "1" || lightswitchBtn.getAttribute("aria-checked") === "true";
+			
+			if (isProtected) {
+				passwordField.style.display = "block";
+				passwordField.classList.remove("hidden");
+			} else {
+				passwordField.style.display = "none";
+				passwordField.classList.add("hidden");
+				this.passwordInput.value = ""; // Clear password when protection is disabled
+			}
+		};
+
+		// Listen to the lightswitch button click
+		lightswitchBtn.addEventListener("click", () => {
+			// Delay to let Craft update the aria-checked and hidden input value
+			setTimeout(updatePasswordFieldVisibility, 50);
+		});
+
+		// Also listen for any change events on the hidden input
+		if (hiddenInput) {
+			hiddenInput.addEventListener("change", updatePasswordFieldVisibility);
+		}
+
+		// Set initial state
+		updatePasswordFieldVisibility();
+	},
+
 	registerTableActions() {
 		document.addEventListener("click", (e) => {
 			const actionEl = e.target.closest(".menu li[data-action]");

--- a/src/controllers/StatusPageController.php
+++ b/src/controllers/StatusPageController.php
@@ -41,7 +41,7 @@ class StatusPageController extends BaseController
             'apiKey' => $settingsService->getApiKey(),
             'apiTokenStatus' => $settingsService->getApiTokenStatus(),
             'apiTokenStatuses' => Constants::API_KEY_STATUS,
-            'upsnapDashboardUrl' => Constants::UPSNAP_DASHBOARD_URL,
+            'upsnapDashboardUrl' => Constants::UPSNAP_STATS_PAGE_URL,
             'userDetails' => $userDetails
         ];
 

--- a/src/controllers/StatusPageController.php
+++ b/src/controllers/StatusPageController.php
@@ -41,7 +41,8 @@ class StatusPageController extends BaseController
             'apiKey' => $settingsService->getApiKey(),
             'apiTokenStatus' => $settingsService->getApiTokenStatus(),
             'apiTokenStatuses' => Constants::API_KEY_STATUS,
-            'upsnapDashboardUrl' => Constants::UPSNAP_STATS_PAGE_URL,
+            'upsnapDashboardUrl' => Constants::UPSNAP_DASHBOARD_URL,
+            'upsnapStatsPageUrl' => Constants::UPSNAP_STATS_PAGE_URL,
             'userDetails' => $userDetails
         ];
 

--- a/src/templates/status-page/_index.twig
+++ b/src/templates/status-page/_index.twig
@@ -24,6 +24,7 @@
 		window.Upsnap = {
 apiKey: {{ apiKey|json_encode|raw }},
 upsnapDashboardUrl: {{ (upsnapDashboardUrl ?? 'unknown')|json_encode|raw }},
+upsnapStatsPageUrl: {{ (upsnapStatsPageUrl ?? 'unknown')|json_encode|raw }},
 userDetails: {{ userDetails|json_encode|raw }}
 };
 	</script>

--- a/src/templates/status-page/new/_index.twig
+++ b/src/templates/status-page/new/_index.twig
@@ -32,7 +32,22 @@ statusPage: {{ statusPage|json_encode|raw }}
 
 			<div id="monitor-multiselect"></div>
 		</div>
+		{{ forms.lightswitchField({
+            label: "Password Protect Status Page",
+            instructions: "Require a password to view this status page.",
+            id: "is_protected",
+            name: "is_protected",
+            on: statusPage ? (statusPage.is_protected ?? false) : false
+        }) }}
 
+		{{ forms.passwordField({
+            label: "Password",
+            id: "password",
+            name: "password",
+            placeholder: 'Enter a secure password',
+            value: "",
+            instructions: "Minimum 8 characters with uppercase, lowercase, number, and special character."
+        }) }}
 		<div class="buttons">
 			<button type="submit" id='status-page-btn' class="btn submit">
 				Save Status Page

--- a/src/templates/status-page/new/_index.twig
+++ b/src/templates/status-page/new/_index.twig
@@ -46,6 +46,7 @@ statusPage: {{ statusPage|json_encode|raw }}
             name: "password",
             placeholder: 'Enter a secure password',
             value: "",
+            autocomplete: "new-password",
             instructions: "Minimum 8 characters with uppercase, lowercase, number, and special character."
         }) }}
 		<div class="buttons">


### PR DESCRIPTION
PR Description:
- Added the support for password protected status pages in the plugin.
- Added the lock icon in the status page list to identify the protected status pages.
<img width="1641" height="811" alt="image" src="https://github.com/user-attachments/assets/0b40bdd3-6674-418b-bf5f-7214bf0371d1" />
<img width="1286" height="725" alt="image" src="https://github.com/user-attachments/assets/410062fa-ec2f-4464-a5e6-2169fa6cd95e" />
