### PR TITLE
feat: incidents listing page

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -98,6 +98,12 @@ class Constants
         'url' => 'upsnap/status-page',
         'template' => 'upsnap/status-page/_index'
     ];
+    const SUBNAV_ITEM_INCIDENTS = [
+        'label' => 'Incidents',
+        'key' => 'incidents',
+        'url' => 'upsnap/incidents',
+        'template' => 'upsnap/incidents/_index'
+    ];
     const SUBNAV_ITEM_SETTINGS = [
         'label' => 'Settings',
         'key' => 'settings',
@@ -121,6 +127,10 @@ class Constants
         self::SUBNAV_ITEM_STATUS_PAGE['key'] => [
             'label' => self::SUBNAV_ITEM_STATUS_PAGE['label'],
             'url' => self::SUBNAV_ITEM_STATUS_PAGE['url']
+        ],
+        self::SUBNAV_ITEM_INCIDENTS['key'] => [
+            'label' => self::SUBNAV_ITEM_INCIDENTS['label'],
+            'url' => self::SUBNAV_ITEM_INCIDENTS['url']
         ],
         self::SUBNAV_ITEM_SETTINGS['key'] => [
             'label' => self::SUBNAV_ITEM_SETTINGS['label'],
@@ -170,6 +180,8 @@ class Constants
             'histogram' => 'user/monitors/{monitorId}/histogram',
             'response_time' => 'user/monitors/{monitorId}/response-time',
             'uptime_stats' => 'user/monitors/{monitorId}/uptime-stats',
+            'incidents' => 'user/monitors/incidents',
+            'export'    => 'user/monitors/{monitorId}/incidents/export',
             'status-page' => [
                 'list' => 'user/status-pages',
                 'detail' => 'user/status-pages',

--- a/src/Upsnap.php
+++ b/src/Upsnap.php
@@ -134,6 +134,11 @@ class Upsnap extends Plugin
                     'upsnap/status-page/new' => 'upsnap/status-page/new',
                     'upsnap/regions/list' => 'upsnap/regions/list',
 
+                    // Incidents Routes
+                    Constants::SUBNAV_ITEM_INCIDENTS['url'] => 'upsnap/incidents/index',
+                    'upsnap/incidents/list'   => 'upsnap/incidents/list',
+                    'upsnap/incidents/export' => 'upsnap/incidents/export',
+
                 ]);
             }
         );

--- a/src/assetbundles/IncidentsAsset.php
+++ b/src/assetbundles/IncidentsAsset.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace appfoster\upsnap\assetbundles;
+
+class IncidentsAsset extends BaseAsset
+{
+    public function init()
+    {
+        parent::init();
+
+        $this->js[]  = 'js/incidents.js';
+        $this->css[] = 'css/incidents.css';
+    }
+}

--- a/src/assetbundles/dist/css/dashboard.css
+++ b/src/assetbundles/dist/css/dashboard.css
@@ -488,12 +488,27 @@
 }
 
 .incidents-table-wrapper .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     font-size: 16px;
     font-weight: 600;
     color: #374151;
     margin-bottom: 16px;
     padding-bottom: 12px;
     border-bottom: 1px solid #e5e7eb;
+}
+
+.incidents-view-all-link {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--link-color, #0d78f2);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.incidents-view-all-link:hover {
+    text-decoration: underline;
 }
 
 .incidents-table-container {

--- a/src/assetbundles/dist/css/incidents.css
+++ b/src/assetbundles/dist/css/incidents.css
@@ -1,0 +1,446 @@
+/* ── incidents.css ─────────────────────────────────────────────────────── */
+
+/* ── Page layout ──────────────────────────────────────────────────────── */
+#incidents-page {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+/* ── Page header ──────────────────────────────────────────────────────── */
+.incidents-page-header__right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+/* ── Label ─────────────────────────────────────────────────────────────── */
+.incidents-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--medium-dark-text-color, #596673);
+    white-space: nowrap;
+}
+
+/* ── Select wrapper (adds Craft-style arrow) ─────────────────────────── */
+.incidents-select-wrap {
+    position: relative;
+    display: inline-flex;
+}
+
+.incidents-select-wrap::after {
+    content: '';
+    position: absolute;
+    right: 9px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid var(--medium-dark-text-color, #596673);
+}
+
+.incidents-select {
+    appearance: none;
+    -webkit-appearance: none;
+    padding: 5px 26px 5px 10px;
+    font-size: 13px;
+    border-radius: 4px;
+    border: 1px solid rgba(0,0,41,.2);
+    background: var(--white, #fff);
+    color: var(--text-color, #3f4d5a);
+    cursor: pointer;
+    min-width: 160px;
+    height: 32px;
+    line-height: 1.3;
+}
+
+.incidents-select:focus {
+    outline: none;
+    border-color: var(--focus-ring-color, #0d78f2);
+    box-shadow: 0 0 0 2px rgba(13,120,242,.15);
+}
+
+.incidents-select-wrap--sm .incidents-select {
+    min-width: 72px;
+}
+
+/* ── Controls bar ─────────────────────────────────────────────────────── */
+.incidents-controls-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.incidents-controls-bar__left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.incidents-controls-bar__right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+/* ── Search ───────────────────────────────────────────────────────────── */
+.incidents-search-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.incidents-search-icon {
+    position: absolute;
+    left: 8px;
+    color: var(--medium-dark-text-color, #596673);
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+}
+
+.incidents-search-input {
+    padding-left: 28px;
+    height: 32px;
+    font-size: 13px;
+    min-width: 200px;
+    border-radius: 4px;
+    border: 1px solid rgba(0,0,41,.2);
+    background: var(--white, #fff);
+    color: var(--text-color, #3f4d5a);
+}
+
+.incidents-search-input:focus {
+    outline: none;
+    border-color: var(--focus-ring-color, #0d78f2);
+    box-shadow: 0 0 0 2px rgba(13,120,242,.15);
+}
+
+/* ── Filter button ────────────────────────────────────────────────────── */
+.incidents-filter-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 32px;
+    padding: 0 10px;
+    font-size: 13px;
+    position: relative;
+}
+
+.incidents-filter-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--blue-600, #0d78f2);
+    color: #fff;
+    border-radius: 9999px;
+    font-size: 10px;
+    font-weight: 700;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    line-height: 1;
+}
+
+/* ── Filter dropdown ──────────────────────────────────────────────────── */
+.incidents-filter-container {
+    position: relative;
+}
+
+.incidents-filter-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 100;
+    background: var(--white, #fff);
+    border: 1px solid rgba(0,0,41,.15);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0,0,0,.12);
+    min-width: 260px;
+    max-width: 340px;
+}
+
+.incidents-filter-dropdown__inner {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    max-height: 480px;
+    overflow-y: auto;
+}
+
+.incidents-filter-section {}
+
+.incidents-filter-section__title {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: var(--medium-dark-text-color, #596673);
+    margin: 0 0 8px;
+}
+
+.incidents-filter-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.incidents-filter-item {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--text-color, #3f4d5a);
+    padding: 3px 0;
+    user-select: none;
+}
+
+.incidents-filter-item input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    cursor: pointer;
+}
+
+.incidents-filter-loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--medium-dark-text-color, #596673);
+}
+
+.incidents-filter-dropdown__footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    padding-top: 4px;
+    border-top: 1px solid rgba(0,0,41,.1);
+}
+
+/* ── Table wrapper ────────────────────────────────────────────────────── */
+.incidents-table-wrapper {
+    position: relative;
+    overflow-x: auto;
+    border-radius: 4px;
+}
+
+/* ── Sortable <th> ────────────────────────────────────────────────────── */
+.incidents-th {
+    white-space: nowrap;
+}
+
+.incidents-th--sortable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.incidents-th--sortable:hover {
+    background: rgba(0,0,0,.04);
+}
+
+/* ── Sort icon ────────────────────────────────────────────────────────── */
+.incidents-sort-icon {
+    display: inline-flex;
+    align-items: center;
+    margin-left: 4px;
+    vertical-align: middle;
+    opacity: .35;
+    transition: opacity .15s;
+}
+
+.incidents-th--sortable:hover .incidents-sort-icon {
+    opacity: .7;
+}
+
+.incidents-sort-icon--asc,
+.incidents-sort-icon--desc {
+    opacity: 1;
+    color: var(--blue-600, #0d78f2);
+}
+
+.incidents-sort-icon--asc svg {
+    transform: scaleY(-1);
+}
+
+/* ── Empty / loading cell ─────────────────────────────────────────────── */
+.incidents-empty-cell {
+    text-align: center;
+    padding: 40px 0 !important;
+    color: var(--medium-dark-text-color, #596673);
+    font-size: 13px;
+}
+
+.incidents-empty-cell svg,
+.incidents-empty-cell .spinner {
+    display: block;
+    margin: 0 auto 10px;
+}
+
+/* ── Incident badges ──────────────────────────────────────────────────── */
+.check-type-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-size: 11px;
+    font-weight: 600;
+    background: rgba(0,0,0,.07);
+    color: var(--text-color, #3f4d5a);
+    white-space: nowrap;
+    text-transform: capitalize;
+}
+
+.check-type-uptime         { background: #e8f4fd; color: #1a6fa8; }
+.check-type-ssl            { background: #eaf4ea; color: #2a7a2a; }
+.check-type-domain         { background: #f3edff; color: #6b4bd8; }
+.check-type-lighthouse     { background: #fff8e1; color: #a07000; }
+.check-type-mixed_content  { background: #fff0e6; color: #b34e00; }
+.check-type-broken_links   { background: #fdedf0; color: #c0243c; }
+
+.region-badge {
+    display: inline-block;
+    font-size: 11px;
+    font-family: var(--font-code, monospace);
+    white-space: nowrap;
+    color: var(--medium-dark-text-color, #596673);
+}
+
+.status-code-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: var(--font-code, monospace);
+    font-weight: 600;
+    background: rgba(0,0,0,.06);
+    color: var(--text-color, #3f4d5a);
+}
+
+/* 2xx green */
+.status-code-badge[class*="status-2"] { background: #eaf4ea; color: #2a7a2a; }
+/* 4xx yellow */
+.status-code-badge[class*="status-4"] { background: #fff8e1; color: #a07000; }
+/* 5xx red */
+.status-code-badge[class*="status-5"] { background: #fdedf0; color: #c0243c; }
+
+.incident-message {
+    font-size: 12px;
+    color: var(--medium-dark-text-color, #596673);
+    max-width: 320px;
+    display: inline-block;
+}
+
+/* ── Loader overlay ───────────────────────────────────────────────────── */
+.incidents-table-wrapper .loader-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(255,255,255,.75);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+    border-radius: 4px;
+}
+
+.incidents-table-wrapper .loader-overlay.hidden {
+    display: none;
+}
+
+/* ── Pagination bar ───────────────────────────────────────────────────── */
+.incidents-pagination-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 8px 0 4px;
+}
+
+.incidents-pagination-bar__left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.incidents-pagination-bar__center {
+    font-size: 13px;
+    color: var(--medium-dark-text-color, #596673);
+}
+
+.incidents-pagination-bar__right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.incidents-page-info {
+    font-size: 13px;
+    color: var(--medium-dark-text-color, #596673);
+    min-width: 90px;
+    text-align: center;
+}
+
+/* ── Export button & dropdown ──────────────────────────────────────────── */
+.incidents-export-container {
+    position: relative;
+}
+
+.incidents-export-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    height: 32px;
+    padding: 0 10px;
+    font-size: 13px;
+}
+
+.incidents-export-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 100;
+    background: var(--white, #fff);
+    border: 1px solid rgba(0,0,41,.15);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0,0,0,.12);
+    min-width: 180px;
+    padding: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.incidents-export-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 7px 10px;
+    font-size: 13px;
+    color: var(--text-color, #3f4d5a);
+    background: none;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    text-align: left;
+}
+
+.incidents-export-option:hover {
+    background: rgba(0,0,0,.05);
+    color: var(--link-color, #0d78f2);
+}

--- a/src/assetbundles/dist/js/incidents.js
+++ b/src/assetbundles/dist/js/incidents.js
@@ -1,0 +1,615 @@
+// incidents.js – Vanilla JS IIFE for the Upsnap Incidents listing page.
+(() => {
+    if (!window.Craft || !window.UpsnapIncidents) {
+        console.error('[Upsnap] incidents.js: required globals missing.');
+        return;
+    }
+
+    /* ─── Config ──────────────────────────────────────────────────────────── */
+    const cfg = window.UpsnapIncidents;
+    console.log('[Upsnap] Incidents config:', cfg);
+
+    /* ─── State ───────────────────────────────────────────────────────────── */
+    const state = {
+        monitorId:   null,
+        timeRange:   '24h',
+        page:        1,
+        pageSize:    20,
+        search:      '',
+        checkTypes:  [],  // committed only on Apply Filters
+        regions:     [],  // committed only on Apply Filters
+        sortBy:      'timestamp',
+        sortOrder:   'desc',
+        // drafted (not yet applied) filter selections
+        _draftCheckTypes: [],
+        _draftRegions:    [],
+    };
+
+    /* ─── Selectors ───────────────────────────────────────────────────────── */
+    const $ = (sel) => document.querySelector(sel);
+    const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+    const el = {
+        monitorSelect:   () => $('#incidents-monitor-select'),
+        timeframeSelect: () => $('#incidents-timeframe-select'),
+        searchInput:     () => $('#incidents-search'),
+        filterBtn:       () => $('#incidents-filter-btn'),
+        filterBadge:     () => $('#incidents-filter-badge'),
+        filterDropdown:  () => $('#incidents-filter-dropdown'),
+        filterContainer: () => $('#incidents-filter-container'),
+        checkTypeCbs:    () => $$('.incidents-checktype-cb'),
+        regionList:      () => $('#incidents-region-filter-list'),
+        regionLoading:   () => $('#incidents-region-loading'),
+        applyFilters:    () => $('#incidents-apply-filters'),
+        clearFilters:    () => $('#incidents-clear-filters'),
+        tbody:           () => $('#incidents-tbody'),
+        loader:          () => $('#incidents-loader'),
+        sortHeaders:     () => $$('.incidents-th--sortable'),
+        pageSizeSelect:  () => $('#incidents-page-size'),
+        prevBtn:         () => $('#incidents-prev-btn'),
+        nextBtn:         () => $('#incidents-next-btn'),
+        showing:         () => $('#incidents-showing'),
+        pageInfo:        () => $('#incidents-page-info'),
+        exportBtn:       () => $('#incidents-export-btn'),
+        exportDropdown:  () => $('#incidents-export-dropdown'),
+        exportContainer: () => $('#incidents-export-container'),
+        exportCsv:       () => $('#incidents-export-csv'),
+        exportPdf:       () => $('#incidents-export-pdf'),
+    };
+
+    /* ─── Helpers ─────────────────────────────────────────────────────────── */
+    const escapeHtml = (str) => {
+        if (!str && str !== 0) return '';
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    };
+
+    const formatDate = (ts) => {
+        if (!ts && ts !== 0) return '—';
+        try {
+            // API returns Unix timestamps in seconds; JS Date needs milliseconds.
+            // If the value is numeric (or a numeric string) treat it as seconds.
+            const ms = isNaN(Number(ts)) ? ts : Number(ts) * 1000;
+            const d = new Date(ms);
+            return d.toLocaleString(undefined, {
+                year: 'numeric', month: 'short', day: 'numeric',
+                hour: '2-digit', minute: '2-digit',
+            });
+        } catch {
+            return String(ts);
+        }
+    };
+
+    const humanCheckType = (v) =>
+        (v || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+    const craftNotice = (msg) => {
+        if (Craft && Craft.cp && Craft.cp.displayNotice) Craft.cp.displayNotice(msg);
+    };
+    const craftError = (msg) => {
+        if (Craft && Craft.cp && Craft.cp.displayError) Craft.cp.displayError(msg);
+    };
+
+    /* ─── Debounce ──────────────────────────────────────────────────────── */
+    let searchDebounceTimer = null;
+    const debounce = (fn, delay) => {
+        clearTimeout(searchDebounceTimer);
+        searchDebounceTimer = setTimeout(fn, delay);
+    };
+
+    /* ─── Convert timeRange string → { start_time, end_time } unix seconds ── */
+    const timeRangeToTimestamps = (range) => {
+        const now = Math.floor(Date.now() / 1000);
+        const offsets = { '24h': 86400, '7d': 604800, '30d': 2592000 };
+        const offset  = offsets[range] ?? 86400;
+        return { start_time: now - offset, end_time: now };
+    };
+
+    /* ─── Populate monitors <select> ──────────────────────────────────────── */
+    const populateMonitorSelect = (monitors) => {
+        const sel = el.monitorSelect();
+        if (!sel) return;
+        sel.innerHTML = '';
+        monitors = monitors.monitors || []
+
+        if (!monitors || !monitors.length) {
+            const opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = 'No monitors found';
+            sel.appendChild(opt);
+            return;
+        }
+
+        monitors.forEach((m) => {
+            const opt = document.createElement('option');
+            opt.value = m.id;
+            opt.textContent = m.name;
+            sel.appendChild(opt);
+        });
+
+        // Pre-select: honour ?monitorId= URL param first, then fall back to first in list
+        const urlMonitorId = new URLSearchParams(window.location.search).get('monitorId');
+        const preselect = urlMonitorId && monitors.find((m) => m.id === urlMonitorId)
+            ? urlMonitorId
+            : monitors[0].id;
+        state.monitorId = preselect;
+        sel.value = state.monitorId;
+    };
+
+    /* ─── Build a table row ────────────────────────────────────────────────── */
+    const buildRow = (inc) => {
+        const tr = document.createElement('tr');
+
+        // Check Type
+        const tdType = document.createElement('td');
+        const typeVal = inc.check_type || '';
+        tdType.innerHTML = `<span class="check-type-badge check-type-${escapeHtml(typeVal)}">${escapeHtml(humanCheckType(typeVal))}</span>`;
+
+        // Region
+        const tdRegion = document.createElement('td');
+        const regionDisplay = regionMap[inc.region] || inc.region || '—';
+        tdRegion.innerHTML = `<span class="region-badge">${escapeHtml(regionDisplay)}</span>`;
+
+        // Message
+        const tdMsg = document.createElement('td');
+        const msg = inc.error_message || inc.message || '';
+        const short = msg.length > 100 ? msg.slice(0, 100) + '…' : msg;
+        tdMsg.innerHTML = `<span class="incident-message" title="${escapeHtml(msg)}">${escapeHtml(short) || '—'}</span>`;
+
+        // Status Code
+        const tdCode = document.createElement('td');
+        const code = inc.status_code != null ? inc.status_code : '—';
+        tdCode.innerHTML = `<span class="status-code-badge status-${escapeHtml(String(code))}">${escapeHtml(String(code))}</span>`;
+
+        // Occurred At
+        const tdTime = document.createElement('td');
+        const ts = inc.timestamp || inc.occurred_at || inc.created_at || '';
+        tdTime.innerHTML = `<time datetime="${escapeHtml(ts)}">${escapeHtml(formatDate(ts))}</time>`;
+
+        tr.append(tdType, tdRegion, tdMsg, tdCode, tdTime);
+        return tr;
+    };
+
+    /* ─── Render table body ───────────────────────────────────────────────── */
+    const renderTable = (incidents) => {
+        const tbody = el.tbody();
+        if (!tbody) return;
+        tbody.innerHTML = '';
+
+        if (!incidents || !incidents.length) {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td colspan="5" class="incidents-empty-cell">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" style="opacity:.4">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                <span>No incidents found.</span>
+            </td>`;
+            tbody.appendChild(tr);
+            return;
+        }
+
+        incidents.forEach((inc) => tbody.appendChild(buildRow(inc)));
+    };
+
+    /* ─── Render pagination ───────────────────────────────────────────────── */
+    const renderPagination = (pagination) => {
+        if (!pagination) return;
+
+        const total      = pagination.total_count   ?? pagination.total        ?? 0;
+        const totalPages = pagination.total_pages   ?? pagination.pages        ?? 1;
+        const current    = pagination.page          ?? pagination.current_page ?? state.page;
+        const perPage    = pagination.page_size     ?? pagination.per_page     ?? state.pageSize;
+
+        const from = total === 0 ? 0 : (current - 1) * perPage + 1;
+        const to   = Math.min(current * perPage, total);
+
+        const showEl    = el.showing();
+        const pageEl    = el.pageInfo();
+        const prevBtn   = el.prevBtn();
+        const nextBtn   = el.nextBtn();
+
+        if (showEl) {
+            showEl.textContent = total === 0
+                ? 'Showing 0 incidents'
+                : `Showing ${from} to ${to} of ${total} incidents`;
+        }
+
+        if (pageEl) {
+            pageEl.textContent = `Page ${current} of ${totalPages}`;
+        }
+
+        if (prevBtn) prevBtn.disabled = current <= 1;
+        if (nextBtn) nextBtn.disabled = current >= totalPages;
+
+        // sync local state to what server returned
+        state.page = current;
+    };
+
+    /* ─── Show / hide loader overlay ─────────────────────────────────────── */
+    const setLoading = (loading) => {
+        const loader = el.loader();
+        if (!loader) return;
+        if (loading) {
+            loader.classList.remove('hidden');
+        } else {
+            loader.classList.add('hidden');
+        }
+    };
+
+    /* ─── Fetch & render ──────────────────────────────────────────────────── */
+    const fetchAndRender = async () => {
+        if (!state.monitorId) {
+            renderTable([]);
+            return;
+        }
+
+        setLoading(true);
+
+        // Build on top of the existing endpoint URL (which may already contain
+        // Craft's ?site= or other query params from actionUrl()).
+        const url = new URL(cfg.listEndpoint, window.location.origin);
+        url.searchParams.set('monitorId',  state.monitorId);
+        url.searchParams.set('time_range', state.timeRange);
+        url.searchParams.set('page',       state.page);
+        url.searchParams.set('page_size',  state.pageSize);
+        url.searchParams.set('sort_by',    state.sortBy);
+        url.searchParams.set('sort_order', state.sortOrder);
+
+        if (state.search)            url.searchParams.set('search',     state.search);
+        if (state.checkTypes.length) url.searchParams.set('check_type', state.checkTypes.join(','));
+        if (state.regions.length)    url.searchParams.set('region',     state.regions.join(','));
+
+        try {
+            const res = await fetch(url.toString(), {
+                headers: {
+                    'Accept':       'application/json',
+                    'X-CSRF-Token': Craft.csrfTokenValue,
+                },
+            });
+
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+            const json = await res.json();
+
+            if (!json.success) {
+                craftError(json.message || 'Failed to fetch incidents.');
+                renderTable([]);
+                return;
+            }
+
+            const responseData = json.data ?? {};
+            renderTable(responseData.incidents ?? []);
+            renderPagination(responseData);
+        } catch (err) {
+            console.error('[Upsnap] incidents fetch error:', err);
+            craftError('Failed to load incidents. Please try again.');
+            renderTable([]);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    /* ─── Sort headers ────────────────────────────────────────────────────── */
+    const updateSortIcons = () => {
+        el.sortHeaders().forEach((th) => {
+            const icon = th.querySelector('.incidents-sort-icon');
+            if (!icon) return;
+            if (th.dataset.sortKey === state.sortBy) {
+                icon.className = `incidents-sort-icon incidents-sort-icon--${state.sortOrder}`;
+                th.setAttribute('aria-sort', state.sortOrder === 'asc' ? 'ascending' : 'descending');
+            } else {
+                icon.className = 'incidents-sort-icon incidents-sort-icon--none';
+                th.removeAttribute('aria-sort');
+            }
+        });
+    };
+
+    const bindSortHeaders = () => {
+        el.sortHeaders().forEach((th) => {
+            th.style.cursor = 'pointer';
+            th.addEventListener('click', () => {
+                const key = th.dataset.sortKey;
+                if (state.sortBy === key) {
+                    state.sortOrder = state.sortOrder === 'asc' ? 'desc' : 'asc';
+                } else {
+                    state.sortBy    = key;
+                    state.sortOrder = 'asc';
+                }
+                state.page = 1;
+                updateSortIcons();
+                fetchAndRender();
+            });
+        });
+    };
+    /* ─── Filter dropdown ────────────────────────────────────────────────── */
+    let regionsLoaded = false;
+    const regionMap = {};  // slug/id → human-readable name
+
+    const loadRegions = async () => {
+        if (regionsLoaded) return;
+
+        try {
+            const res = await fetch(cfg.regionsEndpoint, {
+                headers: {
+                    'Accept':       'application/json',
+                    'X-CSRF-Token': Craft.csrfTokenValue,
+                },
+            });
+            const json = await res.json();
+
+            const listEl = el.regionList();
+            const loadingEl = el.regionLoading();
+            if (loadingEl) loadingEl.remove();
+
+            if (!json.success || !json.data?.length) {
+                if (listEl) listEl.innerHTML = '<p class="light" style="padding:4px 0;font-size:12px;">No regions available.</p>';
+                return;
+            }
+
+            const ul = document.createElement('ul');
+            ul.className = 'incidents-filter-list';
+            ul.id        = 'incidents-region-list';
+
+            json.data.forEach((region) => {
+                const id   = region.id   || region.slug  || region;
+                const name = region.name || region.label || id;
+
+                // Populate the lookup map so buildRow() can resolve names
+                regionMap[String(id)] = String(name);
+
+                const li  = document.createElement('li');
+                li.innerHTML = `
+                    <label class="incidents-filter-item">
+                        <input type="checkbox" class="incidents-region-cb" value="${escapeHtml(String(id))}" />
+                        <span>${escapeHtml(String(name))}</span>
+                    </label>`;
+                ul.appendChild(li);
+            });
+
+            if (listEl) listEl.appendChild(ul);
+            regionsLoaded = true;
+        } catch (err) {
+            console.error('[Upsnap] regions load error:', err);
+            const loadingEl = el.regionLoading();
+            if (loadingEl) loadingEl.innerHTML = '<span style="color:red;font-size:12px;">Failed to load regions.</span>';
+        }
+    };
+
+    const updateFilterBadge = () => {
+        const count = state.checkTypes.length + state.regions.length;
+        const badge = el.filterBadge();
+        if (!badge) return;
+        badge.textContent = count;
+        if (count > 0) badge.classList.remove('hidden');
+        else           badge.classList.add('hidden');
+    };
+
+    const restoreDraftFromState = () => {
+        // sync draft checkboxes to committed state
+        state._draftCheckTypes = [...state.checkTypes];
+        state._draftRegions    = [...state.regions];
+
+        el.checkTypeCbs().forEach((cb) => {
+            cb.checked = state._draftCheckTypes.includes(cb.value);
+        });
+        $$('.incidents-region-cb').forEach((cb) => {
+            cb.checked = state._draftRegions.includes(cb.value);
+        });
+    };
+
+    const bindFilterDropdown = () => {
+        const filterBtn = el.filterBtn();
+        const dropdown  = el.filterDropdown();
+        const applyBtn  = el.applyFilters();
+        const clearBtn  = el.clearFilters();
+
+        if (!filterBtn || !dropdown) return;
+
+        filterBtn.addEventListener('click', async (e) => {
+            e.stopPropagation();
+            const isOpen = !dropdown.classList.contains('hidden');
+            if (isOpen) {
+                dropdown.classList.add('hidden');
+            } else {
+                dropdown.classList.remove('hidden');
+                await loadRegions();
+                restoreDraftFromState();
+            }
+        });
+
+        // close on outside click
+        document.addEventListener('click', (e) => {
+            const container = el.filterContainer();
+            if (container && !container.contains(e.target)) {
+                dropdown.classList.add('hidden');
+            }
+        });
+
+        if (applyBtn) {
+            applyBtn.addEventListener('click', () => {
+                state.checkTypes = $$('.incidents-checktype-cb')
+                    .filter((cb) => cb.checked)
+                    .map((cb) => cb.value);
+
+                state.regions = $$('.incidents-region-cb')
+                    .filter((cb) => cb.checked)
+                    .map((cb) => cb.value);
+
+                state._draftCheckTypes = [...state.checkTypes];
+                state._draftRegions    = [...state.regions];
+
+                state.page = 1;
+                updateFilterBadge();
+                dropdown.classList.add('hidden');
+                fetchAndRender();
+            });
+        }
+
+        if (clearBtn) {
+            clearBtn.addEventListener('click', () => {
+                $$('.incidents-checktype-cb').forEach((cb) => (cb.checked = false));
+                $$('.incidents-region-cb').forEach((cb) => (cb.checked = false));
+                state.checkTypes = [];
+                state.regions    = [];
+                state._draftCheckTypes = [];
+                state._draftRegions    = [];
+                state.page = 1;
+                updateFilterBadge();
+                dropdown.classList.add('hidden');
+                fetchAndRender();
+            });
+        }
+    };
+
+    /* ─── Export dropdown ─────────────────────────────────────────────────── */
+    const triggerExport = (fileType) => {
+        if (!state.monitorId) {
+            craftError('Please select a monitor before exporting.');
+            return;
+        }
+
+        const { start_time, end_time } = timeRangeToTimestamps(state.timeRange);
+
+        const url = new URL(cfg.exportEndpoint, window.location.origin);
+        url.searchParams.set('monitorId',  state.monitorId);
+        url.searchParams.set('file_type',  fileType);
+        url.searchParams.set('start_time', start_time);
+        url.searchParams.set('end_time',   end_time);
+
+        if (state.search)            url.searchParams.set('search', state.search);
+        if (state.checkTypes.length) url.searchParams.set('type',   state.checkTypes.join(','));
+        if (state.regions.length)    url.searchParams.set('region', state.regions.join(','));
+
+        // Trigger browser file download via navigation –
+        // the response carries Content-Disposition: attachment.
+        window.location.href = url.toString();
+
+        const dropdown = el.exportDropdown();
+        if (dropdown) dropdown.classList.add('hidden');
+    };
+
+    const bindExportDropdown = () => {
+        const exportBtn = el.exportBtn();
+        const dropdown  = el.exportDropdown();
+        const csvBtn    = el.exportCsv();
+        const pdfBtn    = el.exportPdf();
+
+        if (!exportBtn || !dropdown) return;
+
+        exportBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            // Close filter dropdown if open
+            const filterDropdown = el.filterDropdown();
+            if (filterDropdown) filterDropdown.classList.add('hidden');
+            dropdown.classList.toggle('hidden');
+        });
+
+        document.addEventListener('click', (e) => {
+            const container = el.exportContainer();
+            if (container && !container.contains(e.target)) {
+                dropdown.classList.add('hidden');
+            }
+        });
+
+        if (csvBtn) csvBtn.addEventListener('click', () => triggerExport('csv'));
+        if (pdfBtn) pdfBtn.addEventListener('click', () => triggerExport('pdf'));
+    };
+
+    /* ─── Bind all other controls ─────────────────────────────────────────── */
+    const bindControls = () => {
+        // Monitor select
+        const monSel = el.monitorSelect();
+        if (monSel) {
+            monSel.addEventListener('change', () => {
+                state.monitorId = monSel.value;
+                state.page = 1;
+                fetchAndRender();
+            });
+        }
+
+        // Timeframe select
+        const timeSel = el.timeframeSelect();
+        if (timeSel) {
+            timeSel.addEventListener('change', () => {
+                state.timeRange = timeSel.value;
+                state.page = 1;
+                fetchAndRender();
+            });
+        }
+
+        // Search input (debounced)
+        const searchInput = el.searchInput();
+        if (searchInput) {
+            searchInput.addEventListener('input', () => {
+                debounce(() => {
+                    state.search = searchInput.value.trim();
+                    state.page = 1;
+                    fetchAndRender();
+                }, 350);
+            });
+        }
+
+        // Rows per page
+        const pageSizeSel = el.pageSizeSelect();
+        if (pageSizeSel) {
+            pageSizeSel.addEventListener('change', () => {
+                state.pageSize = parseInt(pageSizeSel.value, 10) || 20;
+                state.page = 1;
+                fetchAndRender();
+            });
+        }
+
+        // Prev / Next
+        const prevBtn = el.prevBtn();
+        if (prevBtn) {
+            prevBtn.addEventListener('click', () => {
+                if (state.page > 1) {
+                    state.page -= 1;
+                    fetchAndRender();
+                }
+            });
+        }
+
+        const nextBtn = el.nextBtn();
+        if (nextBtn) {
+            nextBtn.addEventListener('click', () => {
+                state.page += 1;
+                fetchAndRender();
+            });
+        }
+    };
+
+    /* ─── Init ────────────────────────────────────────────────────────────── */
+    const init = () => {
+        const monitors = cfg.monitors || [];
+        populateMonitorSelect(monitors);
+
+        bindSortHeaders();
+        updateSortIcons();
+        bindFilterDropdown();
+        bindExportDropdown();
+        bindControls();
+
+        // Eagerly load regions so regionMap is populated before the first
+        // fetchAndRender() call — ensures the Region column shows names.
+        loadRegions();
+
+        if (state.monitorId) {
+            fetchAndRender();
+        } else {
+            setLoading(false);
+            renderTable([]);
+        }
+    };
+
+    // Run after DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/src/controllers/IncidentsController.php
+++ b/src/controllers/IncidentsController.php
@@ -60,19 +60,7 @@ class IncidentsController extends BaseController
     }
 
     /**
-     * JSON endpoint that proxies to the microservice incidents endpoint.
-     * Supports all the query params the microservice accepts.
-     *
-     * GET /actions/upsnap/incidents/list
-     *   ?monitorId=  &time_range=  &page=  &page_size=  &check_type=
-     *   &search=  &sort_by=  &sort_order=  &region=  &include_paused=
-     */
-    /**
-     * Stream a CSV or PDF export directly from the microservice.
-     *
-     * GET /actions/upsnap/incidents/export
-     *   ?monitorId=  &file_type=csv|pdf  &start_time=  &end_time=
-     *   &type=  &search=  &region=
+     * Stream a CSV or PDF export.
      */
     public function actionExport(): Response
     {
@@ -117,6 +105,9 @@ class IncidentsController extends BaseController
         }
     }
 
+    /**
+     * Lists the incidents for a given monitor, with pagination and filtering.
+     */
     public function actionList(): Response
     {
         $request = Craft::$app->getRequest();

--- a/src/controllers/IncidentsController.php
+++ b/src/controllers/IncidentsController.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace appfoster\upsnap\controllers;
+
+use appfoster\upsnap\assetbundles\IncidentsAsset;
+use appfoster\upsnap\Constants;
+use Craft;
+use yii\web\Response;
+use appfoster\upsnap\Upsnap;
+
+class IncidentsController extends BaseController
+{
+    public function __construct($id, $module = null)
+    {
+        parent::__construct($id, $module);
+        IncidentsAsset::register($this->view);
+    }
+
+    /**
+     * Render the incidents listing page.
+     * Passes the monitors list server-side so the page can pre-populate
+     * the monitor <select> without a loading flash.
+     *
+     * GET upsnap/incidents
+     */
+    public function actionIndex(): Response
+    {
+        $settingsService = Upsnap::$plugin->settingsService;
+        $settingsService->validateApiKey();
+
+        $userDetails = null;
+        if ($settingsService->getApiKey()) {
+            $userDetails = $settingsService->getUserDetails();
+        }
+
+        // Pre-fetch monitors for the server-side <select> seed
+        $monitors = [];
+        try {
+            $monitorsEndpoint = Constants::MICROSERVICE_ENDPOINTS['monitors']['list'];
+            $monitorsResponse = Upsnap::$plugin->apiService->get($monitorsEndpoint);
+            if (isset($monitorsResponse['status']) && $monitorsResponse['status'] === 'success') {
+                $monitors = $monitorsResponse['data'] ?? [];
+            }
+        } catch (\Throwable $e) {
+            Craft::error('Failed to pre-fetch monitors for incidents page: ' . $e->getMessage(), __METHOD__);
+        }
+
+        $variables = [
+            'title' => Constants::SUBNAV_ITEM_INCIDENTS['label'],
+            'selectedSubnavItem' => Constants::SUBNAV_ITEM_INCIDENTS['key'],
+            'apiKey' => $settingsService->getApiKey(),
+            'apiTokenStatus' => $settingsService->getApiTokenStatus(),
+            'apiTokenStatuses' => Constants::API_KEY_STATUS,
+            'upsnapDashboardUrl' => Constants::UPSNAP_DASHBOARD_URL,
+            'monitors' => $monitors,
+            'userDetails' => $userDetails,
+        ];
+
+        return $this->renderTemplate('upsnap/incidents/_index', $variables);
+    }
+
+    /**
+     * JSON endpoint that proxies to the microservice incidents endpoint.
+     * Supports all the query params the microservice accepts.
+     *
+     * GET /actions/upsnap/incidents/list
+     *   ?monitorId=  &time_range=  &page=  &page_size=  &check_type=
+     *   &search=  &sort_by=  &sort_order=  &region=  &include_paused=
+     */
+    /**
+     * Stream a CSV or PDF export directly from the microservice.
+     *
+     * GET /actions/upsnap/incidents/export
+     *   ?monitorId=  &file_type=csv|pdf  &start_time=  &end_time=
+     *   &type=  &search=  &region=
+     */
+    public function actionExport(): Response
+    {
+        $request   = Craft::$app->getRequest();
+        $monitorId = $request->getQueryParam('monitorId');
+        $fileType  = $request->getQueryParam('file_type', 'csv');
+
+        if (!$monitorId) {
+            return $this->asJson(['success' => false, 'message' => 'monitorId is required.']);
+        }
+
+        $endpoint = str_replace(
+            '{monitorId}',
+            $monitorId,
+            Constants::MICROSERVICE_ENDPOINTS['monitors']['export']
+        );
+
+        $params = array_filter([
+            'start_time' => $request->getQueryParam('start_time'),
+            'end_time'   => $request->getQueryParam('end_time'),
+            'type'       => $request->getQueryParam('type'),
+            'search'     => $request->getQueryParam('search'),
+            'region'     => $request->getQueryParam('region'),
+            'file_type'  => $fileType,
+        ], fn($v) => $v !== null && $v !== '');
+
+        $accept = $fileType === 'pdf' ? 'application/pdf' : 'text/csv';
+
+        try {
+            $raw = Upsnap::$plugin->apiService->getRaw($endpoint, $params, $accept);
+
+            $craftResponse = Craft::$app->getResponse();
+            $craftResponse->format = \yii\web\Response::FORMAT_RAW;
+            $craftResponse->headers->set('Content-Type',        $raw['contentType']);
+            $craftResponse->headers->set('Content-Disposition', $raw['contentDisposition']);
+            $craftResponse->data = $raw['body'];
+
+            return $craftResponse;
+        } catch (\Throwable $e) {
+            Craft::error('Incidents export failed: ' . $e->getMessage(), __METHOD__);
+            return $this->asJson(['success' => false, 'message' => $e->getMessage()]);
+        }
+    }
+
+    public function actionList(): Response
+    {
+        $request = Craft::$app->getRequest();
+
+        $params = array_filter([
+            'monitorId'      => $request->getQueryParam('monitorId'),
+            'time_range'     => $request->getQueryParam('time_range', '24h'),
+            'page'           => $request->getQueryParam('page', 1),
+            'page_size'      => $request->getQueryParam('page_size', 20),
+            'check_type'     => $request->getQueryParam('check_type'),
+            'search'         => $request->getQueryParam('search'),
+            'sort_by'        => $request->getQueryParam('sort_by', 'timestamp'),
+            'sort_order'     => $request->getQueryParam('sort_order', 'desc'),
+            'region'         => $request->getQueryParam('region'),
+            'include_paused' => $request->getQueryParam('include_paused'),
+        ], fn($v) => $v !== null && $v !== '');
+
+        $endpoint = Constants::MICROSERVICE_ENDPOINTS['monitors']['incidents'];
+
+        try {
+            $response = Upsnap::$plugin->apiService->get($endpoint, $params);
+
+            if (!is_array($response) || !isset($response['status'])) {
+                throw new \Exception(Craft::t('upsnap', 'Something went wrong while fetching incidents. Please try again.'));
+            }
+
+            if ($response['status'] !== 'success') {
+                $errorMsg = $response['message'] ?? Craft::t('upsnap', 'Failed to fetch incidents.');
+                throw new \Exception($errorMsg);
+            }
+
+            return $this->asJson([
+                'success'    => true,
+                'message'    => Craft::t('upsnap', 'Incidents fetched successfully.'),
+                'data'       => $response['data'] ?? [],
+                'pagination' => $response['pagination'] ?? $response['meta'] ?? [],
+            ]);
+        } catch (\Throwable $e) {
+            Craft::error('Incidents fetch failed: ' . $e->getMessage(), __METHOD__);
+
+            return $this->asJson([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -164,6 +164,31 @@ class ApiService extends Component
     }
 
     /**
+     * Make a raw GET request and return the binary body alongside response headers.
+     * Used for file export endpoints (CSV, PDF) that return non-JSON content.
+     *
+     * @return array{body: string, contentType: string, contentDisposition: string}
+     */
+    public function getRaw(string $endpoint, array $query = [], string $accept = '*/*'): array
+    {
+        try {
+            $response = $this->client->get($endpoint, [
+                'headers' => array_merge($this->getHeaders(), ['Accept' => $accept]),
+                'query'   => $query,
+            ]);
+
+            return [
+                'body'               => (string) $response->getBody(),
+                'contentType'        => $response->getHeaderLine('Content-Type')        ?: $accept,
+                'contentDisposition' => $response->getHeaderLine('Content-Disposition') ?: 'attachment; filename=export',
+            ];
+        } catch (RequestException $e) {
+            Craft::error('API getRaw failed: ' . $e->getMessage(), __METHOD__);
+            throw $e;
+        }
+    }
+
+    /**
      * Common headers
      */
     protected function getHeaders(): array

--- a/src/templates/_components/incidents-table.twig
+++ b/src/templates/_components/incidents-table.twig
@@ -2,7 +2,7 @@
 <div id="incidents-table-card" class="incidents-table-wrapper">
 	<div class="card-header">
 		<span>Recent 20 Incidents</span>
-		<a href="{{ cpUrl('upsnap/incidents') ~ (monitorId is defined and monitorId ? '?monitorId=' ~ monitorId : '') }}" class="incidents-view-all-link">
+		<a href="{{ cpUrl('upsnap/incidents', (monitorId is defined and monitorId) ? {'monitorId': monitorId} : {}) }}" class="incidents-view-all-link">
 			{{ 'View all incidents'|t('upsnap') }} &rarr;
 		</a>
 	</div>

--- a/src/templates/_components/incidents-table.twig
+++ b/src/templates/_components/incidents-table.twig
@@ -2,6 +2,9 @@
 <div id="incidents-table-card" class="incidents-table-wrapper">
 	<div class="card-header">
 		<span>Recent 20 Incidents</span>
+		<a href="{{ cpUrl('upsnap/incidents') ~ (monitorId is defined and monitorId ? '?monitorId=' ~ monitorId : '') }}" class="incidents-view-all-link">
+			{{ 'View all incidents'|t('upsnap') }} &rarr;
+		</a>
 	</div>
 	<div class="incidents-table-container">
 		{% if incidents is empty %}

--- a/src/templates/incidents/_index.twig
+++ b/src/templates/incidents/_index.twig
@@ -12,283 +12,284 @@
 {% block actionButton %}
 	<div class="buttons">
 		{% if hasApiKey and isActiveApiToken %}
-                <div class="incidents-page-header__right">
-                <label for="incidents-monitor-select" class="incidents-label">
-                    {{ 'Monitor'|t('upsnap') }}
-                </label>
-                <div class="incidents-select-wrap">
-                    <select id="incidents-monitor-select" class="incidents-select">
-                        <option value="">{{ 'Loading monitors…'|t('upsnap') }}</option>
-                    </select>
-                </div>
-            </div>
+			<div class="incidents-page-header__right">
+				<label for="incidents-monitor-select" class="incidents-label">
+					{{ 'Monitor'|t('upsnap') }}
+				</label>
+				<div class="incidents-select-wrap">
+					<select id="incidents-monitor-select" class="incidents-select">
+						<option value="">{{ 'Loading monitors…'|t('upsnap') }}</option>
+					</select>
+				</div>
+			</div>
 		{% endif %}
 	</div>
 {% endblock %}
 
 {% block content %}
-    <script>
-        window.UpsnapIncidents = {
-            apiKey: {{ apiKey|json_encode|raw }},
-            monitors: {{ monitors|json_encode|raw }},
-            csrfToken: {{ craft.app.request.csrfToken|json_encode|raw }},
-            listEndpoint: "{{ actionUrl('upsnap/incidents/list') }}",
-            exportEndpoint: "{{ actionUrl('upsnap/incidents/export') }}",
-            monitorsEndpoint: "{{ actionUrl('upsnap/monitors/list') }}",
-            regionsEndpoint: "{{ actionUrl('upsnap/regions/list') }}",
-            apiTokenStatus: {{ apiTokenStatus|json_encode|raw }},
-            apiTokenStatuses: {{ apiTokenStatuses|json_encode|raw }},
-            upsnapDashboardUrl: {{ (upsnapDashboardUrl ?? '')|json_encode|raw }}
-        };
-    </script>
+	<script>
+		window.UpsnapIncidents = {
+apiKey: {{ apiKey|json_encode|raw }},
+monitors: {{ monitors|json_encode|raw }},
+csrfToken: {{ craft.app.request.csrfToken|json_encode|raw }},
+listEndpoint: "{{ actionUrl('upsnap/incidents/list') }}",
+exportEndpoint: "{{ actionUrl('upsnap/incidents/export') }}",
+monitorsEndpoint: "{{ actionUrl('upsnap/monitors/list') }}",
+regionsEndpoint: "{{ actionUrl('upsnap/regions/list') }}",
+apiTokenStatus: {{ apiTokenStatus|json_encode|raw }},
+apiTokenStatuses: {{ apiTokenStatuses|json_encode|raw }},
+upsnapDashboardUrl: {{ (upsnapDashboardUrl ?? '')|json_encode|raw }}
+};
+	</script>
 
-    {% if not hasApiKey %}
-        {# ── No API token: registration prompt ───────────────────────────── #}
-        <div class="status-container warning">
-            <div class="status-header">
-                <div class="status-icon warning">!</div>
-                <h3 class="status-title">
-                    {{ 'Need to register for this feature. Please register and add your API token to continue using this feature.'|t('upsnap') }}
-                </h3>
-            </div>
-            <p class="status-message">
-                <a href="{{ cpUrl('upsnap/settings') }}" class="go">{{ 'Go to Settings'|t('upsnap') }}</a>
-                {{ 'to add your API token and unlock the Incidents page.'|t('upsnap') }}
-            </p>
-        </div>
-    {% elseif not isActiveApiToken %}
-        {# ── Token expired/suspended: warning banner, no table ───────────── #}
-        <div class="status-container warning">
-            <div class="status-header">
-                <div class="status-icon warning">!</div>
-                <h3 class="status-title">
-                    {{ 'Your API token is expired or suspended. Please update your API token to continue using the plugin features.'|t('upsnap') }}
-                </h3>
-            </div>
-            <p class="status-message">
-                <a href="{{ cpUrl('upsnap/settings') }}" class="go">{{ 'Go to Settings'|t('upsnap') }}</a>
-                {{ 'to update your API token and restore access to the Incidents page.'|t('upsnap') }}
-            </p>
-        </div>
-    {% else %}
+	{% if not hasApiKey %}
+		{# ── No API token: registration prompt ───────────────────────────── #}
+		<div class="status-container warning">
+			<div class="status-header">
+				<div class="status-icon warning">!</div>
+				<h3 class="status-title">
+					{{ 'Need to register for this feature. Please register and add your API token to continue using this feature.'|t('upsnap') }}
+				</h3>
+			</div>
+			<p class="status-message">
+				<a href="{{ cpUrl('upsnap/settings') }}" class="go">{{ 'Go to Settings'|t('upsnap') }}</a>
+				{{ 'to add your API token and unlock the Incidents page.'|t('upsnap') }}
+			</p>
+		</div>
+	{% elseif not isActiveApiToken %}
+		{# ── Token expired/suspended: warning banner, no table ───────────── #}
+		<div class="status-container warning">
+			<div class="status-header">
+				<div class="status-icon warning">!</div>
+				<h3 class="status-title">
+					{{ 'Your API token is expired or suspended. Please update your API token to continue using the plugin features.'|t('upsnap') }}
+				</h3>
+			</div>
+			<p class="status-message">
+				<a href="{{ cpUrl('upsnap/settings') }}" class="go">{{ 'Go to Settings'|t('upsnap') }}</a>
+				{{ 'to update your API token and restore access to the Incidents page.'|t('upsnap') }}
+			</p>
+		</div>
+	{% else %}
 
-    <div id="incidents-page">
-        {# ── Controls bar: timeframe left · search + filter right ────────────── #}
-        <div class="incidents-controls-bar">
-            <div class="incidents-controls-bar__left">
-                <label for="incidents-timeframe-select" class="incidents-label">
-                    {{ 'Time range'|t('upsnap') }}
-                </label>
-                <div class="incidents-select-wrap">
-                    <select id="incidents-timeframe-select" class="incidents-select">
-                        <option value="24h" selected>{{ 'Last 24 hours'|t('upsnap') }}</option>
-                        <option value="7d">{{ 'Last 7 days'|t('upsnap') }}</option>
-                        <option value="30d">{{ 'Last 30 days'|t('upsnap') }}</option>
-                    </select>
-                </div>
-            </div>
+		<div
+			id="incidents-page">
+			{# ── Controls bar: timeframe left · search + filter right ────────────── #}
+			<div class="incidents-controls-bar">
+				<div class="incidents-controls-bar__left">
+					<label for="incidents-timeframe-select" class="incidents-label">
+						{{ 'Time range'|t('upsnap') }}
+					</label>
+					<div class="incidents-select-wrap">
+						<select id="incidents-timeframe-select" class="incidents-select">
+							<option value="24h" selected>{{ 'Last 24 hours'|t('upsnap') }}</option>
+							<option value="7d">{{ 'Last 7 days'|t('upsnap') }}</option>
+							<option value="30d">{{ 'Last 30 days'|t('upsnap') }}</option>
+						</select>
+					</div>
+				</div>
 
-            <div class="incidents-controls-bar__right">
-                {# Search #}
-                <div class="incidents-search-wrap">
-                    <input
-                        type="text"
-                        id="incidents-search"
-                        class="text incidents-search-input"
-                        placeholder="{{ 'Search incidents…'|t('upsnap') }}"
-                        autocomplete="off"
-                    />
-                </div>
+				<div
+					class="incidents-controls-bar__right">
+					{# Search #}
+					<div class="incidents-search-wrap">
+						<input type="text" id="incidents-search" class="text incidents-search-input" placeholder="{{ 'Search incidents…'|t('upsnap') }}" autocomplete="off"/>
+					</div>
 
-                {# Filter #}
-                <div class="incidents-filter-container" id="incidents-filter-container">
-                    <button type="button" class="btn incidents-filter-btn" id="incidents-filter-btn" title="{{ 'Filters'|t('upsnap') }}">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                            <line x1="4" y1="6" x2="20" y2="6"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="11" y1="18" x2="13" y2="18"/>
-                        </svg>
-                        <span>{{ 'Filters'|t('upsnap') }}</span>
-                        <span class="incidents-filter-badge hidden" id="incidents-filter-badge">0</span>
-                    </button>
+					{# Filter #}
+					<div class="incidents-filter-container" id="incidents-filter-container">
+						<button type="button" class="btn incidents-filter-btn" id="incidents-filter-btn" title="{{ 'Filters'|t('upsnap') }}">
+							<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewbox="0 0 24 24" stroke="currentColor" stroke-width="2">
+								<line x1="4" y1="6" x2="20" y2="6"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="11" y1="18" x2="13" y2="18"/>
+							</svg>
+							<span>{{ 'Filters'|t('upsnap') }}</span>
+							<span class="incidents-filter-badge hidden" id="incidents-filter-badge">0</span>
+						</button>
 
-                    <div class="incidents-filter-dropdown hidden" id="incidents-filter-dropdown">
-                        <div class="incidents-filter-dropdown__inner">
+						<div class="incidents-filter-dropdown hidden" id="incidents-filter-dropdown">
+							<div
+								class="incidents-filter-dropdown__inner">
 
-                            {# Check Type #}
-                            <div class="incidents-filter-section">
-                                <h4 class="incidents-filter-section__title">{{ 'Check Type'|t('upsnap') }}</h4>
-                                <ul class="incidents-filter-list" id="incidents-checktype-list">
-                                    <li>
-                                        <label class="incidents-filter-item">
-                                            <input type="checkbox" class="incidents-checktype-cb" value="uptime" />
-                                            <span>{{ 'Uptime'|t('upsnap') }}</span>
-                                        </label>
-                                    </li>
-                                    <li>
-                                        <label class="incidents-filter-item">
-                                            <input type="checkbox" class="incidents-checktype-cb" value="ssl" />
-                                            <span>{{ 'Security Certificate'|t('upsnap') }}</span>
-                                        </label>
-                                    </li>
-                                    <li>
-                                        <label class="incidents-filter-item">
-                                            <input type="checkbox" class="incidents-checktype-cb" value="domain" />
-                                            <span>{{ 'Domain'|t('upsnap') }}</span>
-                                        </label>
-                                    </li>
-                                    <li>
-                                        <label class="incidents-filter-item">
-                                            <input type="checkbox" class="incidents-checktype-cb" value="lighthouse" />
-                                            <span>{{ 'Lighthouse'|t('upsnap') }}</span>
-                                        </label>
-                                    </li>
-                                    <li>
-                                        <label class="incidents-filter-item">
-                                            <input type="checkbox" class="incidents-checktype-cb" value="mixed_content" />
-                                            <span>{{ 'Mixed Content'|t('upsnap') }}</span>
-                                        </label>
-                                    </li>
-                                    <li>
-                                        <label class="incidents-filter-item">
-                                            <input type="checkbox" class="incidents-checktype-cb" value="broken_links" />
-                                            <span>{{ 'Broken Links'|t('upsnap') }}</span>
-                                        </label>
-                                    </li>
-                                </ul>
-                            </div>
+								{# Check Type #}
+								<div class="incidents-filter-section">
+									<h4 class="incidents-filter-section__title">{{ 'Check Type'|t('upsnap') }}</h4>
+									<ul class="incidents-filter-list" id="incidents-checktype-list">
+										<li>
+											<label class="incidents-filter-item">
+												<input type="checkbox" class="incidents-checktype-cb" value="uptime"/>
+												<span>{{ 'Uptime'|t('upsnap') }}</span>
+											</label>
+										</li>
+										<li>
+											<label class="incidents-filter-item">
+												<input type="checkbox" class="incidents-checktype-cb" value="ssl"/>
+												<span>{{ 'Security Certificate'|t('upsnap') }}</span>
+											</label>
+										</li>
+										<li>
+											<label class="incidents-filter-item">
+												<input type="checkbox" class="incidents-checktype-cb" value="domain"/>
+												<span>{{ 'Domain'|t('upsnap') }}</span>
+											</label>
+										</li>
+										<li>
+											<label class="incidents-filter-item">
+												<input type="checkbox" class="incidents-checktype-cb" value="lighthouse"/>
+												<span>{{ 'Lighthouse'|t('upsnap') }}</span>
+											</label>
+										</li>
+										<li>
+											<label class="incidents-filter-item">
+												<input type="checkbox" class="incidents-checktype-cb" value="mixed_content"/>
+												<span>{{ 'Mixed Content'|t('upsnap') }}</span>
+											</label>
+										</li>
+										<li>
+											<label class="incidents-filter-item">
+												<input type="checkbox" class="incidents-checktype-cb" value="broken_links"/>
+												<span>{{ 'Broken Links'|t('upsnap') }}</span>
+											</label>
+										</li>
+									</ul>
+								</div>
 
-                            {# Region (lazy-loaded) #}
-                            <div class="incidents-filter-section">
-                                <h4 class="incidents-filter-section__title">{{ 'Region'|t('upsnap') }}</h4>
-                                <div id="incidents-region-filter-list">
-                                    <div class="incidents-filter-loading" id="incidents-region-loading">
-                                        <span class="spinner"></span>
-                                        <span>{{ 'Loading regions…'|t('upsnap') }}</span>
-                                    </div>
-                                </div>
-                            </div>
+								{# Region (lazy-loaded) #}
+								<div class="incidents-filter-section">
+									<h4 class="incidents-filter-section__title">{{ 'Region'|t('upsnap') }}</h4>
+									<div id="incidents-region-filter-list">
+										<div class="incidents-filter-loading" id="incidents-region-loading">
+											<span class="spinner"></span>
+											<span>{{ 'Loading regions…'|t('upsnap') }}</span>
+										</div>
+									</div>
+								</div>
 
-                            <div class="incidents-filter-dropdown__footer">
-                                <button type="button" class="btn" id="incidents-clear-filters">
-                                    {{ 'Clear'|t('upsnap') }}
-                                </button>
-                                <button type="button" class="btn submit" id="incidents-apply-filters">
-                                    {{ 'Apply Filters'|t('upsnap') }}
-                                </button>
-                            </div>
+								<div class="incidents-filter-dropdown__footer">
+									<button type="button" class="btn" id="incidents-clear-filters">
+										{{ 'Clear'|t('upsnap') }}
+									</button>
+									<button type="button" class="btn submit" id="incidents-apply-filters">
+										{{ 'Apply Filters'|t('upsnap') }}
+									</button>
+								</div>
 
-                        </div>
-                    </div>
-                </div>
+							</div>
+						</div>
+					</div>
 
-                {# Export #}
-                <div class="incidents-export-container" id="incidents-export-container">
-                    <button type="button" class="btn incidents-export-btn" id="incidents-export-btn" title="{{ 'Export'|t('upsnap') }}">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"/>
-                        </svg>
-                        <span>{{ 'Export'|t('upsnap') }}</span>
-                    </button>
+					{# Export #}
+					<div class="incidents-export-container" id="incidents-export-container">
+						<button type="button" class="btn incidents-export-btn" id="incidents-export-btn" title="{{ 'Export'|t('upsnap') }}">
+							<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewbox="0 0 24 24" stroke="currentColor" stroke-width="2">
+								<path stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"/>
+							</svg>
+							<span>{{ 'Export'|t('upsnap') }}</span>
+						</button>
 
-                    <div class="incidents-export-dropdown hidden" id="incidents-export-dropdown">
-                        <button type="button" class="incidents-export-option" id="incidents-export-csv">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 17v-2m3 2v-4m3 4v-6M5 20h14a2 2 0 002-2V6l-5-5H5a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-                            </svg>
-                            <span>{{ 'Export as CSV'|t('upsnap') }}</span>
-                        </button>
-                        <button type="button" class="incidents-export-option" id="incidents-export-pdf">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
-                            </svg>
-                            <span>{{ 'Export as PDF'|t('upsnap') }}</span>
-                        </button>
-                    </div>
-                </div>
+						<div class="incidents-export-dropdown hidden" id="incidents-export-dropdown">
+							<button type="button" class="incidents-export-option" id="incidents-export-csv">
+								<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewbox="0 0 24 24" stroke="currentColor" stroke-width="2">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M9 17v-2m3 2v-4m3 4v-6M5 20h14a2 2 0 002-2V6l-5-5H5a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+								</svg>
+								<span>{{ 'Export as CSV'|t('upsnap') }}</span>
+							</button>
+							<button type="button" class="incidents-export-option" id="incidents-export-pdf">
+								<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewbox="0 0 24 24" stroke="currentColor" stroke-width="2">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+								</svg>
+								<span>{{ 'Export as PDF'|t('upsnap') }}</span>
+							</button>
+						</div>
+					</div>
 
-            </div>
-        </div>
+				</div>
+			</div>
 
-        {# ── Table ──────────────────────────────────────────────────────────── #}
-        <div class="incidents-table-wrapper" id="incidents-table-wrapper">
-            <div class="loader-overlay" id="incidents-loader">
-                <div class="spinner big"></div>
-            </div>
+			{# ── Table ──────────────────────────────────────────────────────────── #}
+			<div class="incidents-table-wrapper" id="incidents-table-wrapper">
+				<div class="loader-overlay" id="incidents-loader">
+					<div class="spinner big"></div>
+				</div>
 
-            <table class="data fullwidth" id="incidents-table">
-                <thead>
-                    <tr>
-                        <th class="incidents-th incidents-th--sortable" data-sort-key="check_type">
-                            {{ 'Check Type'|t('upsnap') }}
-                            <span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
-                            </span>
-                        </th>
-                        <th class="incidents-th incidents-th--sortable" data-sort-key="region">
-                            {{ 'Region'|t('upsnap') }}
-                            <span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
-                            </span>
-                        </th>
-                        <th class="incidents-th">
-                            {{ 'Message'|t('upsnap') }}
-                        </th>
-                        <th class="incidents-th incidents-th--sortable" data-sort-key="status_code">
-                            {{ 'Status Code'|t('upsnap') }}
-                            <span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
-                            </span>
-                        </th>
-                        <th class="incidents-th incidents-th--sortable" data-sort-key="timestamp">
-                            {{ 'Occurred At'|t('upsnap') }}
-                            <span class="incidents-sort-icon incidents-sort-icon--desc" aria-hidden="true">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
-                            </span>
-                        </th>
-                    </tr>
-                </thead>
-                <tbody id="incidents-tbody">
-                    <tr>
-                        <td colspan="5" class="incidents-empty-cell">
-                            <span class="spinner"></span>
-                            <span>{{ 'Loading incidents…'|t('upsnap') }}</span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+				<table class="data fullwidth" id="incidents-table">
+					<thead>
+						<tr>
+							<th class="incidents-th incidents-th--sortable" data-sort-key="check_type">
+								{{ 'Check Type'|t('upsnap') }}
+								<span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
+									<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewbox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
+								</span>
+							</th>
+							<th class="incidents-th incidents-th--sortable" data-sort-key="region">
+								{{ 'Region'|t('upsnap') }}
+								<span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
+									<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewbox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
+								</span>
+							</th>
+							<th class="incidents-th">
+								{{ 'Message'|t('upsnap') }}
+							</th>
+							<th class="incidents-th incidents-th--sortable" data-sort-key="status_code">
+								{{ 'Status Code'|t('upsnap') }}
+								<span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
+									<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewbox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
+								</span>
+							</th>
+							<th class="incidents-th incidents-th--sortable" data-sort-key="timestamp">
+								{{ 'Occurred At'|t('upsnap') }}
+								<span class="incidents-sort-icon incidents-sort-icon--desc" aria-hidden="true">
+									<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewbox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
+								</span>
+							</th>
+						</tr>
+					</thead>
+					<tbody id="incidents-tbody">
+						<tr>
+							<td colspan="5" class="incidents-empty-cell">
+								<span class="spinner"></span>
+								<span>{{ 'Loading incidents…'|t('upsnap') }}</span>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
 
-        {# ── Pagination bar ────────────────────────────────────────────────── #}
-        <div class="incidents-pagination-bar" id="incidents-pagination-bar">
-            <div class="incidents-pagination-bar__left">
-                <label for="incidents-page-size" class="incidents-label">{{ 'Rows per page'|t('upsnap') }}</label>
-                <div class="incidents-select-wrap incidents-select-wrap--sm">
-                    <select id="incidents-page-size" class="incidents-select">
-                        <option value="20" selected>20</option>
-                        <option value="50">50</option>
-                        <option value="100">100</option>
-                        <option value="200">200</option>
-                    </select>
-                </div>
-            </div>
+			{# ── Pagination bar ────────────────────────────────────────────────── #}
+			<div class="incidents-pagination-bar" id="incidents-pagination-bar">
+				<div class="incidents-pagination-bar__left">
+					<label for="incidents-page-size" class="incidents-label">{{ 'Rows per page'|t('upsnap') }}</label>
+					<div class="incidents-select-wrap incidents-select-wrap--sm">
+						<select id="incidents-page-size" class="incidents-select">
+							<option value="20" selected>20</option>
+							<option value="50">50</option>
+							<option value="100">100</option>
+							<option value="200">200</option>
+						</select>
+					</div>
+				</div>
 
-            <div class="incidents-pagination-bar__center">
-                <span id="incidents-showing">{{ 'Showing 0 incidents'|t('upsnap') }}</span>
-            </div>
+				<div class="incidents-pagination-bar__center">
+					<span id="incidents-showing">{{ 'Showing 0 incidents'|t('upsnap') }}</span>
+				</div>
 
-            <div class="incidents-pagination-bar__right">
-                <button type="button" class="btn small" id="incidents-prev-btn" disabled>
-                    &lsaquo; {{ 'Prev'|t('upsnap') }}
-                </button>
-                <span class="incidents-page-info" id="incidents-page-info">
-                    {{ 'Page 1 of 1'|t('upsnap') }}
-                </span>
-                <button type="button" class="btn small" id="incidents-next-btn" disabled>
-                    {{ 'Next'|t('upsnap') }} &rsaquo;
-                </button>
-            </div>
-        </div>
+				<div class="incidents-pagination-bar__right">
+					<button type="button" class="btn small" id="incidents-prev-btn" disabled>
+						&lsaquo;
+						{{ 'Prev'|t('upsnap') }}
+					</button>
+					<span class="incidents-page-info" id="incidents-page-info">
+						{{ 'Page 1 of 1'|t('upsnap') }}
+					</span>
+					<button type="button" class="btn small" id="incidents-next-btn" disabled>
+						{{ 'Next'|t('upsnap') }}
+						&rsaquo;
+					</button>
+				</div>
+			</div>
 
-    </div>{# /incidents-page #}
+		</div>
+		{# /incidents-page #}
 
-    {% endif %}{# hasApiKey #}
+	{% endif %}
+	{# hasApiKey #}
 {% endblock %}

--- a/src/templates/incidents/_index.twig
+++ b/src/templates/incidents/_index.twig
@@ -1,0 +1,294 @@
+{% extends '_layouts/cp' %}
+{% import '_includes/forms' as forms %}
+
+{% set selectedSubnavItem = 'incidents' %}
+
+{% set crumbs = [
+    { html: "<a href='" ~ url('upsnap') ~ "' class='thumb cp-icon'><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 576 512' focusable='false' aria-hidden='true'><path d='M575.8 255.5c0 18-15 32.1-32 32.1l-32 0 .7 160.2c0 2.7-.2 5.4-.5 8.1l0 16.2c0 22.1-17.9 40-40 40l-16 0c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1L416 512l-24 0c-22.1 0-40-17.9-40-40l0-24 0-64c0-17.7-14.3-32-32-32l-64 0c-17.7 0-32 14.3-32 32l0 64 0 24c0 22.1-17.9 40-40 40l-24 0-31.9 0c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2l-16 0c-22.1 0-40-17.9-40-40l0-112c0-.9 0-1.9 .1-2.8l0-69.7-32 0c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z'></path></svg></a>" },
+] %}
+{% set hasApiKey = apiKey is not empty %}
+{% set isActiveApiToken = apiTokenStatus is same as(apiTokenStatuses.active) %}
+
+{% block actionButton %}
+	<div class="buttons">
+		{% if hasApiKey and isActiveApiToken %}
+                <div class="incidents-page-header__right">
+                <label for="incidents-monitor-select" class="incidents-label">
+                    {{ 'Monitor'|t('upsnap') }}
+                </label>
+                <div class="incidents-select-wrap">
+                    <select id="incidents-monitor-select" class="incidents-select">
+                        <option value="">{{ 'Loading monitors…'|t('upsnap') }}</option>
+                    </select>
+                </div>
+            </div>
+		{% endif %}
+	</div>
+{% endblock %}
+
+{% block content %}
+    <script>
+        window.UpsnapIncidents = {
+            apiKey: {{ apiKey|json_encode|raw }},
+            monitors: {{ monitors|json_encode|raw }},
+            csrfToken: {{ craft.app.request.csrfToken|json_encode|raw }},
+            listEndpoint: "{{ actionUrl('upsnap/incidents/list') }}",
+            exportEndpoint: "{{ actionUrl('upsnap/incidents/export') }}",
+            monitorsEndpoint: "{{ actionUrl('upsnap/monitors/list') }}",
+            regionsEndpoint: "{{ actionUrl('upsnap/regions/list') }}",
+            apiTokenStatus: {{ apiTokenStatus|json_encode|raw }},
+            apiTokenStatuses: {{ apiTokenStatuses|json_encode|raw }},
+            upsnapDashboardUrl: {{ (upsnapDashboardUrl ?? '')|json_encode|raw }}
+        };
+    </script>
+
+    {% if not hasApiKey %}
+        {# ── No API token: registration prompt ───────────────────────────── #}
+        <div class="status-container warning">
+            <div class="status-header">
+                <div class="status-icon warning">!</div>
+                <h3 class="status-title">
+                    {{ 'Need to register for this feature. Please register and add your API token to continue using this feature.'|t('upsnap') }}
+                </h3>
+            </div>
+            <p class="status-message">
+                <a href="{{ cpUrl('upsnap/settings') }}" class="go">{{ 'Go to Settings'|t('upsnap') }}</a>
+                {{ 'to add your API token and unlock the Incidents page.'|t('upsnap') }}
+            </p>
+        </div>
+    {% elseif not isActiveApiToken %}
+        {# ── Token expired/suspended: warning banner, no table ───────────── #}
+        <div class="status-container warning">
+            <div class="status-header">
+                <div class="status-icon warning">!</div>
+                <h3 class="status-title">
+                    {{ 'Your API token is expired or suspended. Please update your API token to continue using the plugin features.'|t('upsnap') }}
+                </h3>
+            </div>
+            <p class="status-message">
+                <a href="{{ cpUrl('upsnap/settings') }}" class="go">{{ 'Go to Settings'|t('upsnap') }}</a>
+                {{ 'to update your API token and restore access to the Incidents page.'|t('upsnap') }}
+            </p>
+        </div>
+    {% else %}
+
+    <div id="incidents-page">
+        {# ── Controls bar: timeframe left · search + filter right ────────────── #}
+        <div class="incidents-controls-bar">
+            <div class="incidents-controls-bar__left">
+                <label for="incidents-timeframe-select" class="incidents-label">
+                    {{ 'Time range'|t('upsnap') }}
+                </label>
+                <div class="incidents-select-wrap">
+                    <select id="incidents-timeframe-select" class="incidents-select">
+                        <option value="24h" selected>{{ 'Last 24 hours'|t('upsnap') }}</option>
+                        <option value="7d">{{ 'Last 7 days'|t('upsnap') }}</option>
+                        <option value="30d">{{ 'Last 30 days'|t('upsnap') }}</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="incidents-controls-bar__right">
+                {# Search #}
+                <div class="incidents-search-wrap">
+                    <input
+                        type="text"
+                        id="incidents-search"
+                        class="text incidents-search-input"
+                        placeholder="{{ 'Search incidents…'|t('upsnap') }}"
+                        autocomplete="off"
+                    />
+                </div>
+
+                {# Filter #}
+                <div class="incidents-filter-container" id="incidents-filter-container">
+                    <button type="button" class="btn incidents-filter-btn" id="incidents-filter-btn" title="{{ 'Filters'|t('upsnap') }}">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <line x1="4" y1="6" x2="20" y2="6"/><line x1="8" y1="12" x2="16" y2="12"/><line x1="11" y1="18" x2="13" y2="18"/>
+                        </svg>
+                        <span>{{ 'Filters'|t('upsnap') }}</span>
+                        <span class="incidents-filter-badge hidden" id="incidents-filter-badge">0</span>
+                    </button>
+
+                    <div class="incidents-filter-dropdown hidden" id="incidents-filter-dropdown">
+                        <div class="incidents-filter-dropdown__inner">
+
+                            {# Check Type #}
+                            <div class="incidents-filter-section">
+                                <h4 class="incidents-filter-section__title">{{ 'Check Type'|t('upsnap') }}</h4>
+                                <ul class="incidents-filter-list" id="incidents-checktype-list">
+                                    <li>
+                                        <label class="incidents-filter-item">
+                                            <input type="checkbox" class="incidents-checktype-cb" value="uptime" />
+                                            <span>{{ 'Uptime'|t('upsnap') }}</span>
+                                        </label>
+                                    </li>
+                                    <li>
+                                        <label class="incidents-filter-item">
+                                            <input type="checkbox" class="incidents-checktype-cb" value="ssl" />
+                                            <span>{{ 'Security Certificate'|t('upsnap') }}</span>
+                                        </label>
+                                    </li>
+                                    <li>
+                                        <label class="incidents-filter-item">
+                                            <input type="checkbox" class="incidents-checktype-cb" value="domain" />
+                                            <span>{{ 'Domain'|t('upsnap') }}</span>
+                                        </label>
+                                    </li>
+                                    <li>
+                                        <label class="incidents-filter-item">
+                                            <input type="checkbox" class="incidents-checktype-cb" value="lighthouse" />
+                                            <span>{{ 'Lighthouse'|t('upsnap') }}</span>
+                                        </label>
+                                    </li>
+                                    <li>
+                                        <label class="incidents-filter-item">
+                                            <input type="checkbox" class="incidents-checktype-cb" value="mixed_content" />
+                                            <span>{{ 'Mixed Content'|t('upsnap') }}</span>
+                                        </label>
+                                    </li>
+                                    <li>
+                                        <label class="incidents-filter-item">
+                                            <input type="checkbox" class="incidents-checktype-cb" value="broken_links" />
+                                            <span>{{ 'Broken Links'|t('upsnap') }}</span>
+                                        </label>
+                                    </li>
+                                </ul>
+                            </div>
+
+                            {# Region (lazy-loaded) #}
+                            <div class="incidents-filter-section">
+                                <h4 class="incidents-filter-section__title">{{ 'Region'|t('upsnap') }}</h4>
+                                <div id="incidents-region-filter-list">
+                                    <div class="incidents-filter-loading" id="incidents-region-loading">
+                                        <span class="spinner"></span>
+                                        <span>{{ 'Loading regions…'|t('upsnap') }}</span>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="incidents-filter-dropdown__footer">
+                                <button type="button" class="btn" id="incidents-clear-filters">
+                                    {{ 'Clear'|t('upsnap') }}
+                                </button>
+                                <button type="button" class="btn submit" id="incidents-apply-filters">
+                                    {{ 'Apply Filters'|t('upsnap') }}
+                                </button>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+
+                {# Export #}
+                <div class="incidents-export-container" id="incidents-export-container">
+                    <button type="button" class="btn incidents-export-btn" id="incidents-export-btn" title="{{ 'Export'|t('upsnap') }}">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"/>
+                        </svg>
+                        <span>{{ 'Export'|t('upsnap') }}</span>
+                    </button>
+
+                    <div class="incidents-export-dropdown hidden" id="incidents-export-dropdown">
+                        <button type="button" class="incidents-export-option" id="incidents-export-csv">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 17v-2m3 2v-4m3 4v-6M5 20h14a2 2 0 002-2V6l-5-5H5a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+                            </svg>
+                            <span>{{ 'Export as CSV'|t('upsnap') }}</span>
+                        </button>
+                        <button type="button" class="incidents-export-option" id="incidents-export-pdf">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+                            </svg>
+                            <span>{{ 'Export as PDF'|t('upsnap') }}</span>
+                        </button>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+
+        {# ── Table ──────────────────────────────────────────────────────────── #}
+        <div class="incidents-table-wrapper" id="incidents-table-wrapper">
+            <div class="loader-overlay" id="incidents-loader">
+                <div class="spinner big"></div>
+            </div>
+
+            <table class="data fullwidth" id="incidents-table">
+                <thead>
+                    <tr>
+                        <th class="incidents-th incidents-th--sortable" data-sort-key="check_type">
+                            {{ 'Check Type'|t('upsnap') }}
+                            <span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
+                            </span>
+                        </th>
+                        <th class="incidents-th incidents-th--sortable" data-sort-key="region">
+                            {{ 'Region'|t('upsnap') }}
+                            <span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
+                            </span>
+                        </th>
+                        <th class="incidents-th">
+                            {{ 'Message'|t('upsnap') }}
+                        </th>
+                        <th class="incidents-th incidents-th--sortable" data-sort-key="status_code">
+                            {{ 'Status Code'|t('upsnap') }}
+                            <span class="incidents-sort-icon incidents-sort-icon--none" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
+                            </span>
+                        </th>
+                        <th class="incidents-th incidents-th--sortable" data-sort-key="timestamp">
+                            {{ 'Occurred At'|t('upsnap') }}
+                            <span class="incidents-sort-icon incidents-sort-icon--desc" aria-hidden="true">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M7 10l5-5 5 5zm0 4l5 5 5-5z"/></svg>
+                            </span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody id="incidents-tbody">
+                    <tr>
+                        <td colspan="5" class="incidents-empty-cell">
+                            <span class="spinner"></span>
+                            <span>{{ 'Loading incidents…'|t('upsnap') }}</span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        {# ── Pagination bar ────────────────────────────────────────────────── #}
+        <div class="incidents-pagination-bar" id="incidents-pagination-bar">
+            <div class="incidents-pagination-bar__left">
+                <label for="incidents-page-size" class="incidents-label">{{ 'Rows per page'|t('upsnap') }}</label>
+                <div class="incidents-select-wrap incidents-select-wrap--sm">
+                    <select id="incidents-page-size" class="incidents-select">
+                        <option value="20" selected>20</option>
+                        <option value="50">50</option>
+                        <option value="100">100</option>
+                        <option value="200">200</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="incidents-pagination-bar__center">
+                <span id="incidents-showing">{{ 'Showing 0 incidents'|t('upsnap') }}</span>
+            </div>
+
+            <div class="incidents-pagination-bar__right">
+                <button type="button" class="btn small" id="incidents-prev-btn" disabled>
+                    &lsaquo; {{ 'Prev'|t('upsnap') }}
+                </button>
+                <span class="incidents-page-info" id="incidents-page-info">
+                    {{ 'Page 1 of 1'|t('upsnap') }}
+                </span>
+                <button type="button" class="btn small" id="incidents-next-btn" disabled>
+                    {{ 'Next'|t('upsnap') }} &rsaquo;
+                </button>
+            </div>
+        </div>
+
+    </div>{# /incidents-page #}
+
+    {% endif %}{# hasApiKey #}
+{% endblock %}


### PR DESCRIPTION
Ticket - https://github.com/Appfoster/site-monitor/issues/23
- Added the incident details page for listing the monitor wise incidents with the csv, pdf export options

<img width="1917" height="925" alt="image" src="https://github.com/user-attachments/assets/9415ed5e-6fcc-4361-ad6d-55a273c65028" />
<img width="1629" height="882" alt="image" src="https://github.com/user-attachments/assets/45717385-d5c9-49cd-817c-32cb38265bd7" />
<img width="768" height="524" alt="image" src="https://github.com/user-attachments/assets/db7ef516-e108-441d-a427-bfc10d6af406" />
