### PR TITLE
fix: Announcement modal UI and Status Page form fixes

### DIFF
--- a/src/assetbundles/dist/css/status-page.css
+++ b/src/assetbundles/dist/css/status-page.css
@@ -507,3 +507,50 @@ body.upsnap-modal-open {
 .btn.icon:not(:empty, .btn-empty)::before, .btn.menubtn:not(.action-btn).icon.btn-empty::before, .btn.menubtn:not(.action-btn).icon:empty::before, .btn.menubtn:not(.action-btn)[data-icon].btn-empty::before, .btn.menubtn:not(.action-btn)[data-icon]:empty::before, .btn[data-icon]:not(:empty, .btn-empty)::before {
   margin-inline-end: 0px;
 }
+
+.upsnap-announcement-modal-fields.upsnap-modal__body {
+	padding: 20px 16px 16px;
+}
+
+.upsnap-announcement-title-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	column-gap: 16px;
+	align-items: start;
+	margin-bottom: 18px;
+}
+
+.upsnap-announcement-title-field {
+	margin: 0 !important;
+	min-width: 0;
+}
+
+.upsnap-announcement-dismissible-field {
+	margin-top: 2px;
+}
+
+.upsnap-modal-field-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+	margin-bottom: 18px;
+}
+
+.upsnap-modal-field-row .field,
+.upsnap-three-col-grid .field {
+	margin: 0 !important;
+}
+
+.upsnap-announcement-modal-fields.upsnap-three-col-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-top: 0;
+}
+
+@media (max-width: 768px) {
+	.upsnap-announcement-title-row,
+	.upsnap-modal-field-row,
+	.upsnap-three-col-grid {
+		grid-template-columns: 1fr;
+	}
+}

--- a/src/assetbundles/dist/css/status-page.css
+++ b/src/assetbundles/dist/css/status-page.css
@@ -547,6 +547,21 @@ body.upsnap-modal-open {
     margin-top: 0;
 }
 
+.announcement-inline-field {
+	display: grid;
+	grid-template-columns: auto minmax(180px, 1fr);
+	align-items: center;
+	column-gap: 12px;
+}
+
+.announcement-inline-field .heading {
+	margin-bottom: 0;
+}
+
+.announcement-inline-field .input {
+	margin-left: auto;
+}
+
 @media (max-width: 768px) {
 	.upsnap-announcement-title-row,
 	.upsnap-modal-field-row,

--- a/src/assetbundles/dist/js/status-pages.js
+++ b/src/assetbundles/dist/js/status-pages.js
@@ -265,8 +265,6 @@ Craft.Upsnap.StatusPages = {
 		this.announcementTypeInput?.addEventListener("change",    revalidate);
 		this.announcementStartAtInput?.addEventListener("change", revalidate);
 		this.announcementStartAtInput?.addEventListener("input",  revalidate);
-		this.announcementEndAtInput?.addEventListener("change",   revalidate);
-		this.announcementEndAtInput?.addEventListener("input",    revalidate);
 	},
 
 	initAnnouncementDateTimePickers() {
@@ -336,7 +334,6 @@ Craft.Upsnap.StatusPages = {
 		const message = (this.announcementMessageInput?.value || "").trim();
 		const type    = this.announcementTypeInput?.value     || "";
 		const startAt = this.announcementStartAtInput?.value  || "";
-		const endAt   = this.announcementEndAtInput?.value    || "";
 
 		const titleOk   = title.length > 0 && title.length <= 100;
 		const messageOk = message.length > 0 && message.length <= 500;
@@ -348,13 +345,7 @@ Craft.Upsnap.StatusPages = {
 			!Number.isNaN(startDate.getTime()) &&
 			startDate >= new Date();
 
-		const endDate = new Date(endAt);
-		const endOk =
-			!!endAt &&
-			!Number.isNaN(endDate.getTime()) &&
-			endDate > startDate;
-
-		const valid = titleOk && messageOk && typeOk && startOk && endOk;
+		const valid = titleOk && messageOk && typeOk && startOk;
 		this.announcementSaveBtn.disabled = !valid;
 		this.announcementSaveBtn.classList.toggle("disabled", !valid);
 	},

--- a/src/assetbundles/dist/js/status-pages.js
+++ b/src/assetbundles/dist/js/status-pages.js
@@ -257,12 +257,25 @@ Craft.Upsnap.StatusPages = {
 		this.announcementDeleteConfirmBtn?.addEventListener("click", () => {
 			this.deleteAnnouncement();
 		});
+
+		const revalidate = () => this.syncAnnouncementSaveBtn();
+
+		this.announcementTitleInput?.addEventListener("input",    revalidate);
+		this.announcementMessageInput?.addEventListener("input",  revalidate);
+		this.announcementTypeInput?.addEventListener("change",    revalidate);
+		this.announcementStartAtInput?.addEventListener("change", revalidate);
+		this.announcementStartAtInput?.addEventListener("input",  revalidate);
+		this.announcementEndAtInput?.addEventListener("change",   revalidate);
+		this.announcementEndAtInput?.addEventListener("input",    revalidate);
 	},
 
 	initAnnouncementDateTimePickers() {
 		if (typeof window.flatpickr !== "function") {
 			return;
 		}
+
+		const now = new Date();
+		now.setSeconds(0, 0);
 
 		const pickerConfig = {
 			enableTime: true,
@@ -273,6 +286,25 @@ Craft.Upsnap.StatusPages = {
 			altInput: true,
 			altFormat: "d/m/Y H:i",
 			disableMobile: true,
+			minDate: now,
+			onChange: () => {
+				this.syncAnnouncementSaveBtn();
+			},
+
+			onClose: () => {
+				this.syncAnnouncementSaveBtn();
+			},
+
+			onReady(_dates, _str, instance) {
+				const input = instance.altInput || instance.input;
+				input.addEventListener("blur", () => {
+					const selected = instance.selectedDates[0];
+					if (selected && selected < new Date()) {
+						instance.clear();
+						Craft.cp.displayError("Past dates are not allowed.");
+					}
+				});
+			},
 		};
 
 		if (this.announcementStartAtPicker) {
@@ -295,6 +327,36 @@ Craft.Upsnap.StatusPages = {
 				pickerConfig
 			);
 		}
+	},
+
+	syncAnnouncementSaveBtn() {
+		if (!this.announcementSaveBtn) return;
+
+		const title   = (this.announcementTitleInput?.value   || "").trim();
+		const message = (this.announcementMessageInput?.value || "").trim();
+		const type    = this.announcementTypeInput?.value     || "";
+		const startAt = this.announcementStartAtInput?.value  || "";
+		const endAt   = this.announcementEndAtInput?.value    || "";
+
+		const titleOk   = title.length > 0 && title.length <= 100;
+		const messageOk = message.length > 0 && message.length <= 500;
+		const typeOk    = ["info", "warning", "critical"].includes(type);
+
+		const startDate = new Date(startAt);
+		const startOk =
+			!!startAt &&
+			!Number.isNaN(startDate.getTime()) &&
+			startDate >= new Date();
+
+		const endDate = new Date(endAt);
+		const endOk =
+			!!endAt &&
+			!Number.isNaN(endDate.getTime()) &&
+			endDate > startDate;
+
+		const valid = titleOk && messageOk && typeOk && startOk && endOk;
+		this.announcementSaveBtn.disabled = !valid;
+		this.announcementSaveBtn.classList.toggle("disabled", !valid);
 	},
 
 	syncAnnouncementCharCounters() {
@@ -526,6 +588,7 @@ Craft.Upsnap.StatusPages = {
 		if (dismissibleSwitch) dismissibleSwitch.value = "1";
 
 		this.syncAnnouncementCharCounters();
+		this.syncAnnouncementSaveBtn();
 		this.openAnnouncementModal();
 	},
 
@@ -591,6 +654,7 @@ Craft.Upsnap.StatusPages = {
 				}
 
 				this.syncAnnouncementCharCounters();
+				this.syncAnnouncementSaveBtn();
 				this.openAnnouncementModal();
 			}
 		);
@@ -680,8 +744,18 @@ Craft.Upsnap.StatusPages = {
 			return false;
 		}
 
-		if (data.start_at && Number.isNaN(new Date(data.start_at).getTime())) {
+		if (!data.start_at) {
+			Craft.cp.displayError("Start Date & Time is required.");
+			return false;
+		}
+
+		if (Number.isNaN(new Date(data.start_at).getTime())) {
 			Craft.cp.displayError("Start Date & Time must be a valid date.");
+			return false;
+		}
+
+		if (new Date(data.start_at) < new Date()) {
+			Craft.cp.displayError("Start Date & Time cannot be in the past.");
 			return false;
 		}
 

--- a/src/templates/status-page/new/_index.twig
+++ b/src/templates/status-page/new/_index.twig
@@ -326,7 +326,7 @@
 
                         <div class="field">
                             <div class="heading">
-                                <label for="announcement_end_at">End Date &amp; Time <span class="required" aria-hidden="true"></span></label>
+                                <label for="announcement_end_at">End Date &amp; Time</label>
                             </div>
                             <div class="input ltr">
                                 <input type="text" class="text fullwidth" id="announcement_end_at" autocomplete="off" placeholder="Select end date and time">

--- a/src/templates/status-page/new/_index.twig
+++ b/src/templates/status-page/new/_index.twig
@@ -15,6 +15,12 @@
 {% endif %}
 
 
+{% block actionButton %}
+    <button type="submit" form="status-page-form" id="status-page-btn" class="btn submit{% if mode == 'edit' %} hidden{% endif %}">
+        Save
+    </button>
+{% endblock %}
+
 {% block content %}
 	<script>
         window.Upsnap = window.Upsnap || {};
@@ -277,15 +283,25 @@
                     <h2 id="announcement-modal-title" class="upsnap-modal__title">Add Announcement</h2>
                     <button type="button" class="upsnap-modal__close" id="announcement-modal-close" aria-label="Close">&times;</button>
                 </div>
-                <div class="upsnap-modal__body">
+                <div class="upsnap-modal__body upsnap-announcement-modal-fields">
                     <input type="hidden" id="announcement_id" value="">
 
-                    <div class="field">
-                        <div class="heading">
-                            <label for="announcement_title">Title <span class="required" aria-hidden="true"></span></label>
+                    <div class="upsnap-announcement-title-row field">
+                        <div class="field upsnap-announcement-title-field">
+                            <div class="heading">
+                                <label for="announcement_title">Title <span class="required" aria-hidden="true"></span></label>
+                            </div>
+                            <div class="input ltr">
+                                <input type="text" class="text fullwidth" id="announcement_title" maxlength="100" required>
+                            </div>
                         </div>
-                        <div class="input ltr">
-                            <input type="text" class="text fullwidth" id="announcement_title" maxlength="100" required>
+                        <div class="upsnap-announcement-dismissible-field">
+                            {{ forms.lightswitchField({
+                                label: "Dismissible",
+                                id: "announcement_is_dismissible",
+                                name: "announcement_is_dismissible",
+                                on: true
+                            }) }}
                         </div>
                     </div>
 
@@ -298,19 +314,19 @@
                         </div>
                     </div>
 
-                    <div class="upsnap-two-col-grid flex">
-                        <div class="field flex-grow">
+                    <div class="upsnap-two-col-grid upsnap-modal-field-row">
+                        <div class="field">
                             <div class="heading">
-                                <label for="announcement_start_at">Start Date &amp; Time</label>
+                                <label for="announcement_start_at">Start Date &amp; Time <span class="required" aria-hidden="true"></span></label>
                             </div>
                             <div class="input ltr">
                                 <input type="text" class="text fullwidth" id="announcement_start_at" autocomplete="off" placeholder="Select start date and time">
                             </div>
                         </div>
 
-                        <div class="field flex-grow">
+                        <div class="field">
                             <div class="heading">
-                                <label for="announcement_end_at">End Date &amp; Time</label>
+                                <label for="announcement_end_at">End Date &amp; Time <span class="required" aria-hidden="true"></span></label>
                             </div>
                             <div class="input ltr">
                                 <input type="text" class="text fullwidth" id="announcement_end_at" autocomplete="off" placeholder="Select end date and time">
@@ -318,8 +334,8 @@
                         </div>
                     </div>
 
-                    <div class="upsnap-three-col-grid flex">
-                        <div class="field flex-grow">
+                    <div class="upsnap-three-col-grid upsnap-announcement-modal-fields">
+                        <div class="field">
                             <div class="heading">
                                 <label for="announcement_type">Type <span class="required" aria-hidden="true"></span></label>
                             </div>
@@ -334,7 +350,7 @@
                             </div>
                         </div>
 
-                        <div class="field flex-grow">
+                        <div class="field">
                             <div class="heading">
                                 <label for="announcement_status">Status</label>
                             </div>
@@ -346,15 +362,6 @@
                                     </select>
                                 </div>
                             </div>
-                        </div>
-
-                        <div class="field flex-grow">
-                            {{ forms.lightswitchField({
-                                label: "Dismissible",
-                                id: "announcement_is_dismissible",
-                                name: "announcement_is_dismissible",
-                                on: true
-                            }) }}
                         </div>
                     </div>
                 </div>
@@ -382,11 +389,5 @@
             </div>
         </div>
         {% endif %}
-
-		<div class="buttons">
-            <button type="submit" id='status-page-btn' class="btn submit{% if mode == 'edit' %} hidden{% endif %}">
-				Save
-			</button>
-		</div>
 	</form>
 {% endblock %}

--- a/src/templates/status-page/new/_index.twig
+++ b/src/templates/status-page/new/_index.twig
@@ -314,7 +314,7 @@
                         </div>
                     </div>
 
-                    <div class="upsnap-two-col-grid upsnap-modal-field-row">
+                    <div class="field upsnap-two-col-grid upsnap-modal-field-row">
                         <div class="field">
                             <div class="heading">
                                 <label for="announcement_start_at">Start Date &amp; Time <span class="required" aria-hidden="true"></span></label>
@@ -335,7 +335,7 @@
                     </div>
 
                     <div class="upsnap-three-col-grid upsnap-announcement-modal-fields">
-                        <div class="field">
+                        <div class="field announcement-inline-field">
                             <div class="heading">
                                 <label for="announcement_type">Type <span class="required" aria-hidden="true"></span></label>
                             </div>
@@ -350,7 +350,7 @@
                             </div>
                         </div>
 
-                        <div class="field">
+                        <div class="field announcement-inline-field">
                             <div class="heading">
                                 <label for="announcement_status">Status</label>
                             </div>


### PR DESCRIPTION
### Ticket  #41 

Fixes - 
- Start date&time should be required 
- Save button should be disabled unless all required fields have valid values entered.
- Past dates should not be allowed to select and not allowed even manually
- Move the Dismissible toggle
- Save button common for General and customisation 